### PR TITLE
Configure axis mapping

### DIFF
--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -95,6 +95,14 @@ bool Adafruit_BNO055::begin(adafruit_bno055_opmode_t mode)
   write8(BNO055_UNIT_SEL_ADDR, unitsel);
   */
 
+  /* Configure axis mapping (see section 3.4) */
+  /*
+  write8(BNO055_AXIS_MAP_CONFIG_ADDR, REMAP_CONFIG_P2); // P0-P7, Default is P1
+  delay(10);
+  write8(BNO055_AXIS_MAP_SIGN_ADDR, REMAP_SIGN_P2); // P0-P7, Default is P1
+  delay(10);
+  */
+  
   write8(BNO055_SYS_TRIGGER_ADDR, 0x0);
   delay(10);
   /* Set the requested operating mode (see section 3.3) */

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -218,6 +218,30 @@ class Adafruit_BNO055 : public Adafruit_Sensor
       OPERATION_MODE_NDOF                                     = 0X0C
     } adafruit_bno055_opmode_t;
 
+    typedef enum
+    {
+      REMAP_CONFIG_P0                                         = 0x21,
+      REMAP_CONFIG_P1                                         = 0x24, // default
+      REMAP_CONFIG_P2                                         = 0x24,
+      REMAP_CONFIG_P3                                         = 0x21,
+      REMAP_CONFIG_P4                                         = 0x24,
+      REMAP_CONFIG_P5                                         = 0x21,
+      REMAP_CONFIG_P6                                         = 0x21,
+      REMAP_CONFIG_P7                                         = 0x24
+    } adafruit_bno055_axis_remap_config_t;
+
+    typedef enum
+    {
+      REMAP_SIGN_P0                                           = 0x04,
+      REMAP_SIGN_P1                                           = 0x00, // default
+      REMAP_SIGN_P2                                           = 0x06,
+      REMAP_SIGN_P3                                           = 0x02,
+      REMAP_SIGN_P4                                           = 0x03,
+      REMAP_SIGN_P5                                           = 0x01,
+      REMAP_SIGN_P6                                           = 0x07,
+      REMAP_SIGN_P7                                           = 0x05
+    } adafruit_bno055_axis_remap_sign_t;
+
     typedef struct
     {
       uint8_t  accel_rev;


### PR DESCRIPTION
Define axis_remap_config and axis_remap_sign for Placement P0 to P7
according to section 3.4.
Add example code in begin function (commented out).