### PR TITLE
Add Calibration Reuse Functionality

### DIFF
--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -15,12 +15,12 @@
   Written by KTOWN for Adafruit Industries.
 
   MIT license, all text above must be included in any redistribution
- ***************************************************************************/
+  ***************************************************************************/
 
 #if ARDUINO >= 100
- #include "Arduino.h"
+#include "Arduino.h"
 #else
- #include "WProgram.h"
+#include "WProgram.h"
 #endif
 
 #include <math.h>
@@ -34,13 +34,13 @@
 
 /**************************************************************************/
 /*!
-    @brief  Instantiates a new Adafruit_BNO055 class
-*/
+	@brief  Instantiates a new Adafruit_BNO055 class
+	*/
 /**************************************************************************/
 Adafruit_BNO055::Adafruit_BNO055(int32_t sensorID, uint8_t address)
 {
-  _sensorID = sensorID;
-  _address = address;
+	_sensorID = sensorID;
+	_address = address;
 }
 
 /***************************************************************************
@@ -49,345 +49,495 @@ Adafruit_BNO055::Adafruit_BNO055(int32_t sensorID, uint8_t address)
 
 /**************************************************************************/
 /*!
-    @brief  Sets up the HW
-*/
+	@brief  Sets up the HW
+	*/
 /**************************************************************************/
 bool Adafruit_BNO055::begin(adafruit_bno055_opmode_t mode)
 {
-  /* Enable I2C */
-  Wire.begin();
+	/* Enable I2C */
+	Wire.begin();
 
-  /* Make sure we have the right device */
-  uint8_t id = read8(BNO055_CHIP_ID_ADDR);
-  if(id != BNO055_ID)
-  {
-    delay(1000); // hold on for boot
-    id = read8(BNO055_CHIP_ID_ADDR);
-    if(id != BNO055_ID) {
-      return false;  // still not? ok bail
-    }
-  }
+	/* Make sure we have the right device */
+	uint8_t id = read8(BNO055_CHIP_ID_ADDR);
+	if (id != BNO055_ID)
+	{
+		delay(1000); // hold on for boot
+		id = read8(BNO055_CHIP_ID_ADDR);
+		if (id != BNO055_ID) {
+			return false;  // still not? ok bail
+		}
+	}
 
-  /* Switch to config mode (just in case since this is the default) */
-  setMode(OPERATION_MODE_CONFIG);
+	/* Switch to config mode (just in case since this is the default) */
+	setMode(OPERATION_MODE_CONFIG);
 
-  /* Reset */
-  write8(BNO055_SYS_TRIGGER_ADDR, 0x20);
-  while (read8(BNO055_CHIP_ID_ADDR) != BNO055_ID)
-  {
-    delay(10);
-  }
-  delay(50);
+	/* Reset */
+	write8(BNO055_SYS_TRIGGER_ADDR, 0x20);
+	while (read8(BNO055_CHIP_ID_ADDR) != BNO055_ID)
+	{
+		delay(10);
+	}
+	delay(50);
 
-  /* Set to normal power mode */
-  write8(BNO055_PWR_MODE_ADDR, POWER_MODE_NORMAL);
-  delay(10);
+	/* Set to normal power mode */
+	write8(BNO055_PWR_MODE_ADDR, POWER_MODE_NORMAL);
+	delay(10);
 
-  write8(BNO055_PAGE_ID_ADDR, 0);
+	write8(BNO055_PAGE_ID_ADDR, 0);
 
-  /* Set the output units */
-  /*
-  uint8_t unitsel = (0 << 7) | // Orientation = Android
-                    (0 << 4) | // Temperature = Celsius
-                    (0 << 2) | // Euler = Degrees
-                    (1 << 1) | // Gyro = Rads
-                    (0 << 0);  // Accelerometer = m/s^2
-  write8(BNO055_UNIT_SEL_ADDR, unitsel);
-  */
+	/* Set the output units */
+	/*
+	uint8_t unitsel = (0 << 7) | // Orientation = Android
+	(0 << 4) | // Temperature = Celsius
+	(0 << 2) | // Euler = Degrees
+	(1 << 1) | // Gyro = Rads
+	(0 << 0);  // Accelerometer = m/s^2
+	write8(BNO055_UNIT_SEL_ADDR, unitsel);
+	*/
 
-  write8(BNO055_SYS_TRIGGER_ADDR, 0x0);
-  delay(10);
-  /* Set the requested operating mode (see section 3.3) */
-  setMode(mode);
-  delay(20);
+	write8(BNO055_SYS_TRIGGER_ADDR, 0x0);
+	delay(10);
+	/* Set the requested operating mode (see section 3.3) */
+	setMode(mode);
+	delay(20);
 
-  return true;
+	return true;
 }
 
 /**************************************************************************/
 /*!
-    @brief  Puts the chip in the specified operating mode
-*/
+	@brief  Puts the chip in the specified operating mode
+	*/
 /**************************************************************************/
 void Adafruit_BNO055::setMode(adafruit_bno055_opmode_t mode)
 {
-  _mode = mode;
-  write8(BNO055_OPR_MODE_ADDR, _mode);
-  delay(30);
+	_mode = mode;
+	write8(BNO055_OPR_MODE_ADDR, _mode);
+	delay(30);
 }
 
 /**************************************************************************/
 /*!
-    @brief  Use the external 32.768KHz crystal
-*/
+	@brief  Use the external 32.768KHz crystal
+	*/
 /**************************************************************************/
 void Adafruit_BNO055::setExtCrystalUse(boolean usextal)
 {
-  adafruit_bno055_opmode_t modeback = _mode;
+	adafruit_bno055_opmode_t modeback = _mode;
 
-  /* Switch to config mode (just in case since this is the default) */
-  setMode(OPERATION_MODE_CONFIG);
-  delay(25);
-  write8(BNO055_PAGE_ID_ADDR, 0);
-  if (usextal) {
-    write8(BNO055_SYS_TRIGGER_ADDR, 0x80);
-  } else {
-    write8(BNO055_SYS_TRIGGER_ADDR, 0x00);
-  }
-  delay(10);
-  /* Set the requested operating mode (see section 3.3) */
-  setMode(modeback);
-  delay(20);
+	/* Switch to config mode (just in case since this is the default) */
+	setMode(OPERATION_MODE_CONFIG);
+	delay(25);
+	write8(BNO055_PAGE_ID_ADDR, 0);
+	if (usextal) {
+		write8(BNO055_SYS_TRIGGER_ADDR, 0x80);
+	}
+	else {
+		write8(BNO055_SYS_TRIGGER_ADDR, 0x00);
+	}
+	delay(10);
+	/* Set the requested operating mode (see section 3.3) */
+	setMode(modeback);
+	delay(20);
 }
 
 
 /**************************************************************************/
 /*!
-    @brief  Gets the latest system status info
-*/
+	@brief  Gets the latest system status info
+	*/
 /**************************************************************************/
 void Adafruit_BNO055::getSystemStatus(uint8_t *system_status, uint8_t *self_test_result, uint8_t *system_error)
 {
-  write8(BNO055_PAGE_ID_ADDR, 0);
+	write8(BNO055_PAGE_ID_ADDR, 0);
 
-  /* System Status (see section 4.3.58)
-     ---------------------------------
-     0 = Idle
-     1 = System Error
-     2 = Initializing Peripherals
-     3 = System Iniitalization
-     4 = Executing Self-Test
-     5 = Sensor fusio algorithm running
-     6 = System running without fusion algorithms */
+	/* System Status (see section 4.3.58)
+	   ---------------------------------
+	   0 = Idle
+	   1 = System Error
+	   2 = Initializing Peripherals
+	   3 = System Iniitalization
+	   4 = Executing Self-Test
+	   5 = Sensor fusio algorithm running
+	   6 = System running without fusion algorithms */
 
-  if (system_status != 0)
-    *system_status    = read8(BNO055_SYS_STAT_ADDR);
+	if (system_status != 0)
+		*system_status = read8(BNO055_SYS_STAT_ADDR);
 
-  /* Self Test Results (see section )
-     --------------------------------
-     1 = test passed, 0 = test failed
+	/* Self Test Results (see section )
+	   --------------------------------
+	   1 = test passed, 0 = test failed
 
-     Bit 0 = Accelerometer self test
-     Bit 1 = Magnetometer self test
-     Bit 2 = Gyroscope self test
-     Bit 3 = MCU self test
+	   Bit 0 = Accelerometer self test
+	   Bit 1 = Magnetometer self test
+	   Bit 2 = Gyroscope self test
+	   Bit 3 = MCU self test
 
-     0x0F = all good! */
+	   0x0F = all good! */
 
-  if (self_test_result != 0)
-    *self_test_result = read8(BNO055_SELFTEST_RESULT_ADDR);
+	if (self_test_result != 0)
+		*self_test_result = read8(BNO055_SELFTEST_RESULT_ADDR);
 
-  /* System Error (see section 4.3.59)
-     ---------------------------------
-     0 = No error
-     1 = Peripheral initialization error
-     2 = System initialization error
-     3 = Self test result failed
-     4 = Register map value out of range
-     5 = Register map address out of range
-     6 = Register map write error
-     7 = BNO low power mode not available for selected operat ion mode
-     8 = Accelerometer power mode not available
-     9 = Fusion algorithm configuration error
-     A = Sensor configuration error */
+	/* System Error (see section 4.3.59)
+	   ---------------------------------
+	   0 = No error
+	   1 = Peripheral initialization error
+	   2 = System initialization error
+	   3 = Self test result failed
+	   4 = Register map value out of range
+	   5 = Register map address out of range
+	   6 = Register map write error
+	   7 = BNO low power mode not available for selected operat ion mode
+	   8 = Accelerometer power mode not available
+	   9 = Fusion algorithm configuration error
+	   A = Sensor configuration error */
 
-  if (system_error != 0)
-    *system_error     = read8(BNO055_SYS_ERR_ADDR);
+	if (system_error != 0)
+		*system_error = read8(BNO055_SYS_ERR_ADDR);
 
-  delay(200);
+	delay(200);
 }
 
 /**************************************************************************/
 /*!
-    @brief  Gets the chip revision numbers
-*/
+	@brief  Gets the chip revision numbers
+	*/
 /**************************************************************************/
 void Adafruit_BNO055::getRevInfo(adafruit_bno055_rev_info_t* info)
 {
-  uint8_t a, b;
+	uint8_t a, b;
 
-  memset(info, 0, sizeof(adafruit_bno055_rev_info_t));
+	memset(info, 0, sizeof(adafruit_bno055_rev_info_t));
 
-  /* Check the accelerometer revision */
-  info->accel_rev = read8(BNO055_ACCEL_REV_ID_ADDR);
+	/* Check the accelerometer revision */
+	info->accel_rev = read8(BNO055_ACCEL_REV_ID_ADDR);
 
-  /* Check the magnetometer revision */
-  info->mag_rev   = read8(BNO055_MAG_REV_ID_ADDR);
+	/* Check the magnetometer revision */
+	info->mag_rev = read8(BNO055_MAG_REV_ID_ADDR);
 
-  /* Check the gyroscope revision */
-  info->gyro_rev  = read8(BNO055_GYRO_REV_ID_ADDR);
+	/* Check the gyroscope revision */
+	info->gyro_rev = read8(BNO055_GYRO_REV_ID_ADDR);
 
-  /* Check the SW revision */
-  info->bl_rev    = read8(BNO055_BL_REV_ID_ADDR);
+	/* Check the SW revision */
+	info->bl_rev = read8(BNO055_BL_REV_ID_ADDR);
 
-  a = read8(BNO055_SW_REV_ID_LSB_ADDR);
-  b = read8(BNO055_SW_REV_ID_MSB_ADDR);
-  info->sw_rev = (((uint16_t)b) << 8) | ((uint16_t)a);
+	a = read8(BNO055_SW_REV_ID_LSB_ADDR);
+	b = read8(BNO055_SW_REV_ID_MSB_ADDR);
+	info->sw_rev = (((uint16_t)b) << 8) | ((uint16_t)a);
 }
 
 /**************************************************************************/
 /*!
-    @brief  Gets current calibration state.  Each value should be a uint8_t
-            pointer and it will be set to 0 if not calibrated and 3 if
-            fully calibrated.
-*/
+	@brief  Gets current calibration state.  Each value should be a uint8_t
+	pointer and it will be set to 0 if not calibrated and 3 if
+	fully calibrated.
+	*/
 /**************************************************************************/
 void Adafruit_BNO055::getCalibration(uint8_t* sys, uint8_t* gyro, uint8_t* accel, uint8_t* mag) {
-  uint8_t calData = read8(BNO055_CALIB_STAT_ADDR);
-  if (sys != NULL) {
-    *sys = (calData >> 6) & 0x03;
-  }
-  if (gyro != NULL) {
-    *gyro = (calData >> 4) & 0x03;
-  }
-  if (accel != NULL) {
-    *accel = (calData >> 2) & 0x03;
-  }
-  if (mag != NULL) {
-    *mag = calData & 0x03;
-  }
+	uint8_t calData = read8(BNO055_CALIB_STAT_ADDR);
+	if (sys != NULL) {
+		*sys = (calData >> 6) & 0x03;
+	}
+	if (gyro != NULL) {
+		*gyro = (calData >> 4) & 0x03;
+	}
+	if (accel != NULL) {
+		*accel = (calData >> 2) & 0x03;
+	}
+	if (mag != NULL) {
+		*mag = calData & 0x03;
+	}
 }
 
 /**************************************************************************/
 /*!
-    @brief  Gets the temperature in degrees celsius
-*/
+	@brief  Gets the temperature in degrees celsius
+	*/
 /**************************************************************************/
 int8_t Adafruit_BNO055::getTemp(void)
 {
-  int8_t temp = (int8_t)(read8(BNO055_TEMP_ADDR));
-  return temp;
+	int8_t temp = (int8_t)(read8(BNO055_TEMP_ADDR));
+	return temp;
 }
 
 /**************************************************************************/
 /*!
-    @brief  Gets a vector reading from the specified source
-*/
+	@brief  Gets a vector reading from the specified source
+	*/
 /**************************************************************************/
 imu::Vector<3> Adafruit_BNO055::getVector(adafruit_vector_type_t vector_type)
 {
-  imu::Vector<3> xyz;
-  uint8_t buffer[6];
-  memset (buffer, 0, 6);
+	imu::Vector<3> xyz;
+	uint8_t buffer[6];
+	memset(buffer, 0, 6);
 
-  int16_t x, y, z;
-  x = y = z = 0;
+	int16_t x, y, z;
+	x = y = z = 0;
 
-  /* Read vector data (6 bytes) */
-  readLen((adafruit_bno055_reg_t)vector_type, buffer, 6);
+	/* Read vector data (6 bytes) */
+	readLen((adafruit_bno055_reg_t)vector_type, buffer, 6);
 
-  x = ((int16_t)buffer[0]) | (((int16_t)buffer[1]) << 8);
-  y = ((int16_t)buffer[2]) | (((int16_t)buffer[3]) << 8);
-  z = ((int16_t)buffer[4]) | (((int16_t)buffer[5]) << 8);
+	x = ((int16_t)buffer[0]) | (((int16_t)buffer[1]) << 8);
+	y = ((int16_t)buffer[2]) | (((int16_t)buffer[3]) << 8);
+	z = ((int16_t)buffer[4]) | (((int16_t)buffer[5]) << 8);
 
-  /* Convert the value to an appropriate range (section 3.6.4) */
-  /* and assign the value to the Vector type */
-  switch(vector_type)
-  {
-    case VECTOR_MAGNETOMETER:
-      /* 1uT = 16 LSB */
-      xyz[0] = ((double)x)/16.0;
-      xyz[1] = ((double)y)/16.0;
-      xyz[2] = ((double)z)/16.0;
-      break;
-    case VECTOR_GYROSCOPE:
-      /* 1rps = 900 LSB */
-      xyz[0] = ((double)x)/900.0;
-      xyz[1] = ((double)y)/900.0;
-      xyz[2] = ((double)z)/900.0;
-      break;
-    case VECTOR_EULER:
-      /* 1 degree = 16 LSB */
-      xyz[0] = ((double)x)/16.0;
-      xyz[1] = ((double)y)/16.0;
-      xyz[2] = ((double)z)/16.0;
-      break;
-    case VECTOR_ACCELEROMETER:
-    case VECTOR_LINEARACCEL:
-    case VECTOR_GRAVITY:
-      /* 1m/s^2 = 100 LSB */
-      xyz[0] = ((double)x)/100.0;
-      xyz[1] = ((double)y)/100.0;
-      xyz[2] = ((double)z)/100.0;
-      break;
-  }
+	/* Convert the value to an appropriate range (section 3.6.4) */
+	/* and assign the value to the Vector type */
+	switch (vector_type)
+	{
+	case VECTOR_MAGNETOMETER:
+		/* 1uT = 16 LSB */
+		xyz[0] = ((double)x) / 16.0;
+		xyz[1] = ((double)y) / 16.0;
+		xyz[2] = ((double)z) / 16.0;
+		break;
+	case VECTOR_GYROSCOPE:
+		/* 1rps = 900 LSB */
+		xyz[0] = ((double)x) / 900.0;
+		xyz[1] = ((double)y) / 900.0;
+		xyz[2] = ((double)z) / 900.0;
+		break;
+	case VECTOR_EULER:
+		/* 1 degree = 16 LSB */
+		xyz[0] = ((double)x) / 16.0;
+		xyz[1] = ((double)y) / 16.0;
+		xyz[2] = ((double)z) / 16.0;
+		break;
+	case VECTOR_ACCELEROMETER:
+	case VECTOR_LINEARACCEL:
+	case VECTOR_GRAVITY:
+		/* 1m/s^2 = 100 LSB */
+		xyz[0] = ((double)x) / 100.0;
+		xyz[1] = ((double)y) / 100.0;
+		xyz[2] = ((double)z) / 100.0;
+		break;
+	}
 
-  return xyz;
+	return xyz;
 }
 
 /**************************************************************************/
 /*!
-    @brief  Gets a quaternion reading from the specified source
-*/
+	@brief  Gets a quaternion reading from the specified source
+	*/
 /**************************************************************************/
 imu::Quaternion Adafruit_BNO055::getQuat(void)
 {
-  uint8_t buffer[8];
-  memset (buffer, 0, 8);
+	uint8_t buffer[8];
+	memset(buffer, 0, 8);
 
-  int16_t x, y, z, w;
-  x = y = z = w = 0;
+	int16_t x, y, z, w;
+	x = y = z = w = 0;
 
-  /* Read quat data (8 bytes) */
-  readLen(BNO055_QUATERNION_DATA_W_LSB_ADDR, buffer, 8);
-  w = (((uint16_t)buffer[1]) << 8) | ((uint16_t)buffer[0]);
-  x = (((uint16_t)buffer[3]) << 8) | ((uint16_t)buffer[2]);
-  y = (((uint16_t)buffer[5]) << 8) | ((uint16_t)buffer[4]);
-  z = (((uint16_t)buffer[7]) << 8) | ((uint16_t)buffer[6]);
+	/* Read quat data (8 bytes) */
+	readLen(BNO055_QUATERNION_DATA_W_LSB_ADDR, buffer, 8);
+	w = (((uint16_t)buffer[1]) << 8) | ((uint16_t)buffer[0]);
+	x = (((uint16_t)buffer[3]) << 8) | ((uint16_t)buffer[2]);
+	y = (((uint16_t)buffer[5]) << 8) | ((uint16_t)buffer[4]);
+	z = (((uint16_t)buffer[7]) << 8) | ((uint16_t)buffer[6]);
 
-  /* Assign to Quaternion */
-  /* See http://ae-bst.resource.bosch.com/media/products/dokumente/bno055/BST_BNO055_DS000_12~1.pdf
-     3.6.5.5 Orientation (Quaternion)  */
-  const double scale = (1.0 / (1<<14));
-  imu::Quaternion quat(scale * w, scale * x, scale * y, scale * z);
-  return quat;
+	/* Assign to Quaternion */
+	/* See http://ae-bst.resource.bosch.com/media/products/dokumente/bno055/BST_BNO055_DS000_12~1.pdf
+	   3.6.5.5 Orientation (Quaternion)  */
+	const double scale = (1.0 / (1 << 14));
+	imu::Quaternion quat(scale * w, scale * x, scale * y, scale * z);
+	return quat;
 }
 
 /**************************************************************************/
 /*!
-    @brief  Provides the sensor_t data for this sensor
-*/
+	@brief  Provides the sensor_t data for this sensor
+	*/
 /**************************************************************************/
 void Adafruit_BNO055::getSensor(sensor_t *sensor)
 {
-  /* Clear the sensor_t object */
-  memset(sensor, 0, sizeof(sensor_t));
+	/* Clear the sensor_t object */
+	memset(sensor, 0, sizeof(sensor_t));
 
-  /* Insert the sensor name in the fixed length char array */
-  strncpy (sensor->name, "BNO055", sizeof(sensor->name) - 1);
-  sensor->name[sizeof(sensor->name)- 1] = 0;
-  sensor->version     = 1;
-  sensor->sensor_id   = _sensorID;
-  sensor->type        = SENSOR_TYPE_ORIENTATION;
-  sensor->min_delay   = 0;
-  sensor->max_value   = 0.0F;
-  sensor->min_value   = 0.0F;
-  sensor->resolution  = 0.01F;
+	/* Insert the sensor name in the fixed length char array */
+	strncpy(sensor->name, "BNO055", sizeof(sensor->name) - 1);
+	sensor->name[sizeof(sensor->name) - 1] = 0;
+	sensor->version = 1;
+	sensor->sensor_id = _sensorID;
+	sensor->type = SENSOR_TYPE_ORIENTATION;
+	sensor->min_delay = 0;
+	sensor->max_value = 0.0F;
+	sensor->min_value = 0.0F;
+	sensor->resolution = 0.01F;
 }
 
 /**************************************************************************/
 /*!
-    @brief  Reads the sensor and returns the data as a sensors_event_t
-*/
+	@brief  Reads the sensor and returns the data as a sensors_event_t
+	*/
 /**************************************************************************/
 bool Adafruit_BNO055::getEvent(sensors_event_t *event)
 {
-  /* Clear the event */
-  memset(event, 0, sizeof(sensors_event_t));
+	/* Clear the event */
+	memset(event, 0, sizeof(sensors_event_t));
 
-  event->version   = sizeof(sensors_event_t);
-  event->sensor_id = _sensorID;
-  event->type      = SENSOR_TYPE_ORIENTATION;
-  event->timestamp = millis();
+	event->version = sizeof(sensors_event_t);
+	event->sensor_id = _sensorID;
+	event->type = SENSOR_TYPE_ORIENTATION;
+	event->timestamp = millis();
 
-  /* Get a Euler angle sample for orientation */
-  imu::Vector<3> euler = getVector(Adafruit_BNO055::VECTOR_EULER);
-  event->orientation.x = euler.x();
-  event->orientation.y = euler.y();
-  event->orientation.z = euler.z();
+	/* Get a Euler angle sample for orientation */
+	imu::Vector<3> euler = getVector(Adafruit_BNO055::VECTOR_EULER);
+	event->orientation.x = euler.x();
+	event->orientation.y = euler.y();
+	event->orientation.z = euler.z();
 
-  return true;
+	return true;
 }
+
+/**************************************************************************/
+/*!
+@brief  Reads the sensor's offset registers into a byte array
+*/
+/**************************************************************************/
+bool Adafruit_BNO055::getSensorOffsets(int8_t* calibData)
+{
+	if (isFullyCalibrated())
+	{
+		adafruit_bno055_opmode_t lastMode = _mode;
+		setMode(OPERATION_MODE_CONFIG);
+
+		readLen(ACCEL_OFFSET_X_LSB_ADDR, calibData, NUM_BNO055_OFFSET_REGISTERS);
+
+		setMode(lastMode);
+		return true;
+	}
+	return false;
+}
+
+/**************************************************************************/
+/*!
+@brief  Reads the sensor's offset registers into an offset struct
+*/
+/**************************************************************************/
+bool Adafruit_BNO055::getSensorOffsets(adafruit_bno055_offsets_t &offsets_type)
+{
+	if (isFullyCalibrated())
+	{
+		adafruit_bno055_opmode_t lastMode = _mode;
+		setMode(OPERATION_MODE_CONFIG);
+		delay(25);
+
+		offsets_type.accel_offset_x = (read8(ACCEL_OFFSET_X_MSB_ADDR) << 8) | (read8(ACCEL_OFFSET_X_LSB_ADDR));
+		offsets_type.accel_offset_y = (read8(ACCEL_OFFSET_Y_MSB_ADDR) << 8) | (read8(ACCEL_OFFSET_Y_LSB_ADDR));
+		offsets_type.accel_offset_z = (read8(ACCEL_OFFSET_Z_MSB_ADDR) << 8) | (read8(ACCEL_OFFSET_Z_LSB_ADDR));
+
+		offsets_type.gyro_offset_x = (read8(GYRO_OFFSET_X_MSB_ADDR) << 8) | (read8(GYRO_OFFSET_X_LSB_ADDR));
+		offsets_type.gyro_offset_y = (read8(GYRO_OFFSET_Y_MSB_ADDR) << 8) | (read8(GYRO_OFFSET_Y_LSB_ADDR));
+		offsets_type.gyro_offset_z = (read8(GYRO_OFFSET_Z_MSB_ADDR) << 8) | (read8(GYRO_OFFSET_Z_LSB_ADDR));
+
+		offsets_type.mag_offset_x = (read8(MAG_OFFSET_X_MSB_ADDR) << 8) | (read8(MAG_OFFSET_X_LSB_ADDR));
+		offsets_type.mag_offset_y = (read8(MAG_OFFSET_Y_MSB_ADDR) << 8) | (read8(MAG_OFFSET_Y_LSB_ADDR));
+		offsets_type.mag_offset_z = (read8(MAG_OFFSET_Z_MSB_ADDR) << 8) | (read8(MAG_OFFSET_Z_LSB_ADDR));
+
+		offsets_type.accel_radius = (read8(ACCEL_RADIUS_MSB_ADDR) << 8) | (read8(ACCEL_RADIUS_LSB_ADDR));
+		offsets_type.mag_radius = (read8(MAG_RADIUS_MSB_ADDR) << 8) | (read8(MAG_RADIUS_LSB_ADDR));
+
+		setMode(lastMode);
+		return true;
+	}
+	return false;
+}
+
+
+/**************************************************************************/
+/*!
+@brief  Writes an array of calibration values to the sensor's offset registers
+*/
+/**************************************************************************/
+void Adafruit_BNO055::setSensorOffsets(const int8_t* calibData)
+{
+	adafruit_bno055_opmode_t lastMode = _mode;
+	setMode(OPERATION_MODE_CONFIG);
+	delay(25);
+
+	/* A writeLen() would make this much cleaner */
+	write8(ACCEL_OFFSET_X_LSB_ADDR, calibData[0]);
+	write8(ACCEL_OFFSET_X_MSB_ADDR, calibData[1]);
+	write8(ACCEL_OFFSET_Y_LSB_ADDR, calibData[2]);
+	write8(ACCEL_OFFSET_Y_MSB_ADDR, calibData[3]);
+	write8(ACCEL_OFFSET_Z_LSB_ADDR, calibData[4]);
+	write8(ACCEL_OFFSET_Z_MSB_ADDR, calibData[5]);
+
+	write8(GYRO_OFFSET_X_LSB_ADDR, calibData[6]);
+	write8(GYRO_OFFSET_X_MSB_ADDR, calibData[7]);
+	write8(GYRO_OFFSET_Y_LSB_ADDR, calibData[8]);
+	write8(GYRO_OFFSET_Y_MSB_ADDR, calibData[9]);
+	write8(GYRO_OFFSET_Z_LSB_ADDR, calibData[10]);
+	write8(GYRO_OFFSET_Z_MSB_ADDR, calibData[11]);
+
+	write8(MAG_OFFSET_X_LSB_ADDR, calibData[12]);
+	write8(MAG_OFFSET_X_MSB_ADDR, calibData[13]);
+	write8(MAG_OFFSET_Y_LSB_ADDR, calibData[14]);
+	write8(MAG_OFFSET_Y_MSB_ADDR, calibData[15]);
+	write8(MAG_OFFSET_Z_LSB_ADDR, calibData[16]);
+	write8(MAG_OFFSET_Z_MSB_ADDR, calibData[17]);
+
+	write8(ACCEL_RADIUS_LSB_ADDR, calibData[18]);
+	write8(ACCEL_RADIUS_MSB_ADDR, calibData[19]);
+
+	write8(MAG_RADIUS_LSB_ADDR, calibData[20]);
+	write8(MAG_RADIUS_MSB_ADDR, calibData[21]);
+
+	setMode(lastMode);
+}
+
+/**************************************************************************/
+/*!
+@brief  Writes to the sensor's offset registers from an offset struct
+*/
+/**************************************************************************/
+void Adafruit_BNO055::setSensorOffsets(const adafruit_bno055_offsets_t &offsets_type)
+{
+	adafruit_bno055_opmode_t lastMode = _mode;
+	setMode(OPERATION_MODE_CONFIG);
+	delay(25);
+
+	write8(ACCEL_OFFSET_X_LSB_ADDR, (offsets_type.accel_offset_x) & 0x0FF);
+	write8(ACCEL_OFFSET_X_MSB_ADDR, (offsets_type.accel_offset_x >> 8) & 0x0FF);
+	write8(ACCEL_OFFSET_Y_LSB_ADDR, (offsets_type.accel_offset_y) & 0x0FF);
+	write8(ACCEL_OFFSET_Y_MSB_ADDR, (offsets_type.accel_offset_y >> 8) & 0x0FF);
+	write8(ACCEL_OFFSET_Z_LSB_ADDR, (offsets_type.accel_offset_z) & 0x0FF);
+	write8(ACCEL_OFFSET_Z_MSB_ADDR, (offsets_type.accel_offset_z >> 8) & 0x0FF);
+
+	write8(GYRO_OFFSET_X_LSB_ADDR, (offsets_type.gyro_offset_x) & 0x0FF);
+	write8(GYRO_OFFSET_X_MSB_ADDR, (offsets_type.gyro_offset_x >> 8) & 0x0FF);
+	write8(GYRO_OFFSET_Y_LSB_ADDR, (offsets_type.gyro_offset_y) & 0x0FF);
+	write8(GYRO_OFFSET_Y_MSB_ADDR, (offsets_type.gyro_offset_y >> 8) & 0x0FF);
+	write8(GYRO_OFFSET_Z_LSB_ADDR, (offsets_type.gyro_offset_z) & 0x0FF);
+	write8(GYRO_OFFSET_Z_MSB_ADDR, (offsets_type.gyro_offset_z >> 8) & 0x0FF);
+
+	write8(MAG_OFFSET_X_LSB_ADDR, (offsets_type.mag_offset_x) & 0x0FF);
+	write8(MAG_OFFSET_X_MSB_ADDR, (offsets_type.mag_offset_x >> 8) & 0x0FF);
+	write8(MAG_OFFSET_Y_LSB_ADDR, (offsets_type.mag_offset_y) & 0x0FF);
+	write8(MAG_OFFSET_Y_MSB_ADDR, (offsets_type.mag_offset_y >> 8) & 0x0FF);
+	write8(MAG_OFFSET_Z_LSB_ADDR, (offsets_type.mag_offset_z) & 0x0FF);
+	write8(MAG_OFFSET_Z_MSB_ADDR, (offsets_type.mag_offset_z >> 8) & 0x0FF);
+
+	write8(ACCEL_RADIUS_LSB_ADDR, (offsets_type.accel_radius) & 0x0FF);
+	write8(ACCEL_RADIUS_MSB_ADDR, (offsets_type.accel_radius >> 8) & 0x0FF);
+
+	write8(MAG_RADIUS_LSB_ADDR, (offsets_type.mag_radius) & 0x0FF);
+	write8(MAG_RADIUS_MSB_ADDR, (offsets_type.mag_radius >> 8) & 0x0FF);
+
+	setMode(lastMode);
+}
+
+bool Adafruit_BNO055::isFullyCalibrated(void)
+{
+	uint8_t system, gyro, accel, mag;
+	getCalibration(&system, &gyro, &accel, &mag);
+	if (system < 3 || gyro < 3 || accel < 3 || mag < 3)
+		return false;
+	return true;
+}
+
+
 
 /***************************************************************************
  PRIVATE FUNCTIONS
@@ -395,76 +545,76 @@ bool Adafruit_BNO055::getEvent(sensors_event_t *event)
 
 /**************************************************************************/
 /*!
-    @brief  Writes an 8 bit value over I2C
-*/
+	@brief  Writes an 8 bit value over I2C
+	*/
 /**************************************************************************/
 bool Adafruit_BNO055::write8(adafruit_bno055_reg_t reg, byte value)
 {
-  Wire.beginTransmission(_address);
-  #if ARDUINO >= 100
-    Wire.write((uint8_t)reg);
-    Wire.write((uint8_t)value);
-  #else
-    Wire.send(reg);
-    Wire.send(value);
-  #endif
-  Wire.endTransmission();
+	Wire.beginTransmission(_address);
+#if ARDUINO >= 100
+	Wire.write((uint8_t)reg);
+	Wire.write((uint8_t)value);
+#else
+	Wire.send(reg);
+	Wire.send(value);
+#endif
+	Wire.endTransmission();
 
-  /* ToDo: Check for error! */
-  return true;
+	/* ToDo: Check for error! */
+	return true;
 }
 
 /**************************************************************************/
 /*!
-    @brief  Reads an 8 bit value over I2C
-*/
+	@brief  Reads an 8 bit value over I2C
+	*/
 /**************************************************************************/
-byte Adafruit_BNO055::read8(adafruit_bno055_reg_t reg )
+byte Adafruit_BNO055::read8(adafruit_bno055_reg_t reg)
 {
-  byte value = 0;
+	byte value = 0;
 
-  Wire.beginTransmission(_address);
-  #if ARDUINO >= 100
-    Wire.write((uint8_t)reg);
-  #else
-    Wire.send(reg);
-  #endif
-  Wire.endTransmission();
-  Wire.requestFrom(_address, (byte)1);
-  #if ARDUINO >= 100
-    value = Wire.read();
-  #else
-    value = Wire.receive();
-  #endif
+	Wire.beginTransmission(_address);
+#if ARDUINO >= 100
+	Wire.write((uint8_t)reg);
+#else
+	Wire.send(reg);
+#endif
+	Wire.endTransmission();
+	Wire.requestFrom(_address, (byte)1);
+#if ARDUINO >= 100
+	value = Wire.read();
+#else
+	value = Wire.receive();
+#endif
 
-  return value;
+	return value;
 }
 
 /**************************************************************************/
 /*!
-    @brief  Reads the specified number of bytes over I2C
-*/
+	@brief  Reads the specified number of bytes over I2C
+	*/
 /**************************************************************************/
 bool Adafruit_BNO055::readLen(adafruit_bno055_reg_t reg, byte * buffer, uint8_t len)
 {
-  Wire.beginTransmission(_address);
-  #if ARDUINO >= 100
-    Wire.write((uint8_t)reg);
-  #else
-    Wire.send(reg);
-  #endif
-  Wire.endTransmission();
-  Wire.requestFrom(_address, (byte)len);
+	Wire.beginTransmission(_address);
+#if ARDUINO >= 100
+	Wire.write((uint8_t)reg);
+#else
+	Wire.send(reg);
+#endif
+	Wire.endTransmission();
+	Wire.requestFrom(_address, (byte)len);
 
-  for (uint8_t i = 0; i < len; i++)
-  {
-    #if ARDUINO >= 100
-      buffer[i] = Wire.read();
-    #else
-      buffer[i] = Wire.receive();
-    #endif
-  }
+	for (uint8_t i = 0; i < len; i++)
+	{
+#if ARDUINO >= 100
+		buffer[i] = Wire.read();
+#else
+		buffer[i] = Wire.receive();
+#endif
+	}
 
-  /* ToDo: Check for errors! */
-  return true;
+	/* ToDo: Check for errors! */
+	return true;
 }

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -395,7 +395,7 @@ bool Adafruit_BNO055::getEvent(sensors_event_t *event)
 @brief  Reads the sensor's offset registers into a byte array
 */
 /**************************************************************************/
-bool Adafruit_BNO055::getSensorOffsets(int8_t* calibData)
+bool Adafruit_BNO055::getSensorOffsets(uint8_t* calibData)
 {
 	if (isFullyCalibrated())
 	{
@@ -450,7 +450,7 @@ bool Adafruit_BNO055::getSensorOffsets(adafruit_bno055_offsets_t &offsets_type)
 @brief  Writes an array of calibration values to the sensor's offset registers
 */
 /**************************************************************************/
-void Adafruit_BNO055::setSensorOffsets(const int8_t* calibData)
+void Adafruit_BNO055::setSensorOffsets(const uint8_t* calibData)
 {
 	adafruit_bno055_opmode_t lastMode = _mode;
 	setMode(OPERATION_MODE_CONFIG);

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -44,18 +44,18 @@
 
 typedef struct
 {
-	int16_t accel_offset_x;
-	int16_t accel_offset_y;
-	int16_t accel_offset_z;
-	int16_t gyro_offset_x;
-	int16_t gyro_offset_y;
-	int16_t gyro_offset_z;
-	int16_t mag_offset_x;
-	int16_t mag_offset_y;
-	int16_t mag_offset_z;
+	uint16_t accel_offset_x;
+	uint16_t accel_offset_y;
+	uint16_t accel_offset_z;
+	uint16_t gyro_offset_x;
+	uint16_t gyro_offset_y;
+	uint16_t gyro_offset_z;
+	uint16_t mag_offset_x;
+	uint16_t mag_offset_y;
+	uint16_t mag_offset_z;
 
-	int16_t accel_radius;
-	int16_t mag_radius;
+	uint16_t accel_radius;
+	uint16_t mag_radius;
 } adafruit_bno055_offsets_t;
 
 class Adafruit_BNO055 : public Adafruit_Sensor
@@ -279,9 +279,9 @@ public:
 	void  getSensor(sensor_t*);
 
 	/* Functions to deal with raw calibration data */
-	bool  getSensorOffsets(int8_t* calibData);
+	bool  getSensorOffsets(uint8_t* calibData);
 	bool  getSensorOffsets(adafruit_bno055_offsets_t &offsets_type);
-	void  setSensorOffsets(const int8_t* calibData);
+	void  setSensorOffsets(const uint8_t* calibData);
 	void  setSensorOffsets(const adafruit_bno055_offsets_t &offsets_type);
 	bool  isFullyCalibrated(void);
 

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -15,22 +15,22 @@
   Written by KTOWN for Adafruit Industries.
 
   MIT license, all text above must be included in any redistribution
- ***************************************************************************/
+  ***************************************************************************/
 
 #ifndef __ADAFRUIT_BNO055_H__
 #define __ADAFRUIT_BNO055_H__
 
 #if (ARDUINO >= 100)
- #include "Arduino.h"
+#include "Arduino.h"
 #else
- #include "WProgram.h"
+#include "WProgram.h"
 #endif
 
 #ifdef __AVR_ATtiny85__
- #include <TinyWireM.h>
- #define Wire TinyWireM
+#include <TinyWireM.h>
+#define Wire TinyWireM
 #else
- #include <Wire.h>
+#include <Wire.h>
 #endif
 
 #include <Adafruit_Sensor.h>
@@ -40,232 +40,259 @@
 #define BNO055_ADDRESS_B (0x29)
 #define BNO055_ID        (0xA0)
 
+#define NUM_BNO055_OFFSET_REGISTERS (22)
+
+typedef struct
+{
+	int16_t accel_offset_x;
+	int16_t accel_offset_y;
+	int16_t accel_offset_z;
+	int16_t gyro_offset_x;
+	int16_t gyro_offset_y;
+	int16_t gyro_offset_z;
+	int16_t mag_offset_x;
+	int16_t mag_offset_y;
+	int16_t mag_offset_z;
+
+	int16_t accel_radius;
+	int16_t mag_radius;
+} adafruit_bno055_offsets_t;
+
 class Adafruit_BNO055 : public Adafruit_Sensor
 {
-  public:
-    typedef enum
-    {
-      /* Page id register definition */
-      BNO055_PAGE_ID_ADDR                                     = 0X07,
+public:
+	typedef enum
+	{
+		/* Page id register definition */
+		BNO055_PAGE_ID_ADDR = 0X07,
 
-      /* PAGE0 REGISTER DEFINITION START*/
-      BNO055_CHIP_ID_ADDR                                     = 0x00,
-      BNO055_ACCEL_REV_ID_ADDR                                = 0x01,
-      BNO055_MAG_REV_ID_ADDR                                  = 0x02,
-      BNO055_GYRO_REV_ID_ADDR                                 = 0x03,
-      BNO055_SW_REV_ID_LSB_ADDR                               = 0x04,
-      BNO055_SW_REV_ID_MSB_ADDR                               = 0x05,
-      BNO055_BL_REV_ID_ADDR                                   = 0X06,
+		/* PAGE0 REGISTER DEFINITION START*/
+		BNO055_CHIP_ID_ADDR = 0x00,
+		BNO055_ACCEL_REV_ID_ADDR = 0x01,
+		BNO055_MAG_REV_ID_ADDR = 0x02,
+		BNO055_GYRO_REV_ID_ADDR = 0x03,
+		BNO055_SW_REV_ID_LSB_ADDR = 0x04,
+		BNO055_SW_REV_ID_MSB_ADDR = 0x05,
+		BNO055_BL_REV_ID_ADDR = 0X06,
 
-      /* Accel data register */
-      BNO055_ACCEL_DATA_X_LSB_ADDR                            = 0X08,
-      BNO055_ACCEL_DATA_X_MSB_ADDR                            = 0X09,
-      BNO055_ACCEL_DATA_Y_LSB_ADDR                            = 0X0A,
-      BNO055_ACCEL_DATA_Y_MSB_ADDR                            = 0X0B,
-      BNO055_ACCEL_DATA_Z_LSB_ADDR                            = 0X0C,
-      BNO055_ACCEL_DATA_Z_MSB_ADDR                            = 0X0D,
+		/* Accel data register */
+		BNO055_ACCEL_DATA_X_LSB_ADDR = 0X08,
+		BNO055_ACCEL_DATA_X_MSB_ADDR = 0X09,
+		BNO055_ACCEL_DATA_Y_LSB_ADDR = 0X0A,
+		BNO055_ACCEL_DATA_Y_MSB_ADDR = 0X0B,
+		BNO055_ACCEL_DATA_Z_LSB_ADDR = 0X0C,
+		BNO055_ACCEL_DATA_Z_MSB_ADDR = 0X0D,
 
-      /* Mag data register */
-      BNO055_MAG_DATA_X_LSB_ADDR                              = 0X0E,
-      BNO055_MAG_DATA_X_MSB_ADDR                              = 0X0F,
-      BNO055_MAG_DATA_Y_LSB_ADDR                              = 0X10,
-      BNO055_MAG_DATA_Y_MSB_ADDR                              = 0X11,
-      BNO055_MAG_DATA_Z_LSB_ADDR                              = 0X12,
-      BNO055_MAG_DATA_Z_MSB_ADDR                              = 0X13,
+		/* Mag data register */
+		BNO055_MAG_DATA_X_LSB_ADDR = 0X0E,
+		BNO055_MAG_DATA_X_MSB_ADDR = 0X0F,
+		BNO055_MAG_DATA_Y_LSB_ADDR = 0X10,
+		BNO055_MAG_DATA_Y_MSB_ADDR = 0X11,
+		BNO055_MAG_DATA_Z_LSB_ADDR = 0X12,
+		BNO055_MAG_DATA_Z_MSB_ADDR = 0X13,
 
-      /* Gyro data registers */
-      BNO055_GYRO_DATA_X_LSB_ADDR                             = 0X14,
-      BNO055_GYRO_DATA_X_MSB_ADDR                             = 0X15,
-      BNO055_GYRO_DATA_Y_LSB_ADDR                             = 0X16,
-      BNO055_GYRO_DATA_Y_MSB_ADDR                             = 0X17,
-      BNO055_GYRO_DATA_Z_LSB_ADDR                             = 0X18,
-      BNO055_GYRO_DATA_Z_MSB_ADDR                             = 0X19,
+		/* Gyro data registers */
+		BNO055_GYRO_DATA_X_LSB_ADDR = 0X14,
+		BNO055_GYRO_DATA_X_MSB_ADDR = 0X15,
+		BNO055_GYRO_DATA_Y_LSB_ADDR = 0X16,
+		BNO055_GYRO_DATA_Y_MSB_ADDR = 0X17,
+		BNO055_GYRO_DATA_Z_LSB_ADDR = 0X18,
+		BNO055_GYRO_DATA_Z_MSB_ADDR = 0X19,
 
-      /* Euler data registers */
-      BNO055_EULER_H_LSB_ADDR                                 = 0X1A,
-      BNO055_EULER_H_MSB_ADDR                                 = 0X1B,
-      BNO055_EULER_R_LSB_ADDR                                 = 0X1C,
-      BNO055_EULER_R_MSB_ADDR                                 = 0X1D,
-      BNO055_EULER_P_LSB_ADDR                                 = 0X1E,
-      BNO055_EULER_P_MSB_ADDR                                 = 0X1F,
+		/* Euler data registers */
+		BNO055_EULER_H_LSB_ADDR = 0X1A,
+		BNO055_EULER_H_MSB_ADDR = 0X1B,
+		BNO055_EULER_R_LSB_ADDR = 0X1C,
+		BNO055_EULER_R_MSB_ADDR = 0X1D,
+		BNO055_EULER_P_LSB_ADDR = 0X1E,
+		BNO055_EULER_P_MSB_ADDR = 0X1F,
 
-      /* Quaternion data registers */
-      BNO055_QUATERNION_DATA_W_LSB_ADDR                       = 0X20,
-      BNO055_QUATERNION_DATA_W_MSB_ADDR                       = 0X21,
-      BNO055_QUATERNION_DATA_X_LSB_ADDR                       = 0X22,
-      BNO055_QUATERNION_DATA_X_MSB_ADDR                       = 0X23,
-      BNO055_QUATERNION_DATA_Y_LSB_ADDR                       = 0X24,
-      BNO055_QUATERNION_DATA_Y_MSB_ADDR                       = 0X25,
-      BNO055_QUATERNION_DATA_Z_LSB_ADDR                       = 0X26,
-      BNO055_QUATERNION_DATA_Z_MSB_ADDR                       = 0X27,
+		/* Quaternion data registers */
+		BNO055_QUATERNION_DATA_W_LSB_ADDR = 0X20,
+		BNO055_QUATERNION_DATA_W_MSB_ADDR = 0X21,
+		BNO055_QUATERNION_DATA_X_LSB_ADDR = 0X22,
+		BNO055_QUATERNION_DATA_X_MSB_ADDR = 0X23,
+		BNO055_QUATERNION_DATA_Y_LSB_ADDR = 0X24,
+		BNO055_QUATERNION_DATA_Y_MSB_ADDR = 0X25,
+		BNO055_QUATERNION_DATA_Z_LSB_ADDR = 0X26,
+		BNO055_QUATERNION_DATA_Z_MSB_ADDR = 0X27,
 
-      /* Linear acceleration data registers */
-      BNO055_LINEAR_ACCEL_DATA_X_LSB_ADDR                     = 0X28,
-      BNO055_LINEAR_ACCEL_DATA_X_MSB_ADDR                     = 0X29,
-      BNO055_LINEAR_ACCEL_DATA_Y_LSB_ADDR                     = 0X2A,
-      BNO055_LINEAR_ACCEL_DATA_Y_MSB_ADDR                     = 0X2B,
-      BNO055_LINEAR_ACCEL_DATA_Z_LSB_ADDR                     = 0X2C,
-      BNO055_LINEAR_ACCEL_DATA_Z_MSB_ADDR                     = 0X2D,
+		/* Linear acceleration data registers */
+		BNO055_LINEAR_ACCEL_DATA_X_LSB_ADDR = 0X28,
+		BNO055_LINEAR_ACCEL_DATA_X_MSB_ADDR = 0X29,
+		BNO055_LINEAR_ACCEL_DATA_Y_LSB_ADDR = 0X2A,
+		BNO055_LINEAR_ACCEL_DATA_Y_MSB_ADDR = 0X2B,
+		BNO055_LINEAR_ACCEL_DATA_Z_LSB_ADDR = 0X2C,
+		BNO055_LINEAR_ACCEL_DATA_Z_MSB_ADDR = 0X2D,
 
-      /* Gravity data registers */
-      BNO055_GRAVITY_DATA_X_LSB_ADDR                          = 0X2E,
-      BNO055_GRAVITY_DATA_X_MSB_ADDR                          = 0X2F,
-      BNO055_GRAVITY_DATA_Y_LSB_ADDR                          = 0X30,
-      BNO055_GRAVITY_DATA_Y_MSB_ADDR                          = 0X31,
-      BNO055_GRAVITY_DATA_Z_LSB_ADDR                          = 0X32,
-      BNO055_GRAVITY_DATA_Z_MSB_ADDR                          = 0X33,
+		/* Gravity data registers */
+		BNO055_GRAVITY_DATA_X_LSB_ADDR = 0X2E,
+		BNO055_GRAVITY_DATA_X_MSB_ADDR = 0X2F,
+		BNO055_GRAVITY_DATA_Y_LSB_ADDR = 0X30,
+		BNO055_GRAVITY_DATA_Y_MSB_ADDR = 0X31,
+		BNO055_GRAVITY_DATA_Z_LSB_ADDR = 0X32,
+		BNO055_GRAVITY_DATA_Z_MSB_ADDR = 0X33,
 
-      /* Temperature data register */
-      BNO055_TEMP_ADDR                                        = 0X34,
+		/* Temperature data register */
+		BNO055_TEMP_ADDR = 0X34,
 
-      /* Status registers */
-      BNO055_CALIB_STAT_ADDR                                  = 0X35,
-      BNO055_SELFTEST_RESULT_ADDR                             = 0X36,
-      BNO055_INTR_STAT_ADDR                                   = 0X37,
+		/* Status registers */
+		BNO055_CALIB_STAT_ADDR = 0X35,
+		BNO055_SELFTEST_RESULT_ADDR = 0X36,
+		BNO055_INTR_STAT_ADDR = 0X37,
 
-      BNO055_SYS_CLK_STAT_ADDR                                = 0X38,
-      BNO055_SYS_STAT_ADDR                                    = 0X39,
-      BNO055_SYS_ERR_ADDR                                     = 0X3A,
+		BNO055_SYS_CLK_STAT_ADDR = 0X38,
+		BNO055_SYS_STAT_ADDR = 0X39,
+		BNO055_SYS_ERR_ADDR = 0X3A,
 
-      /* Unit selection register */
-      BNO055_UNIT_SEL_ADDR                                    = 0X3B,
-      BNO055_DATA_SELECT_ADDR                                 = 0X3C,
+		/* Unit selection register */
+		BNO055_UNIT_SEL_ADDR = 0X3B,
+		BNO055_DATA_SELECT_ADDR = 0X3C,
 
-      /* Mode registers */
-      BNO055_OPR_MODE_ADDR                                    = 0X3D,
-      BNO055_PWR_MODE_ADDR                                    = 0X3E,
+		/* Mode registers */
+		BNO055_OPR_MODE_ADDR = 0X3D,
+		BNO055_PWR_MODE_ADDR = 0X3E,
 
-      BNO055_SYS_TRIGGER_ADDR                                 = 0X3F,
-      BNO055_TEMP_SOURCE_ADDR                                 = 0X40,
+		BNO055_SYS_TRIGGER_ADDR = 0X3F,
+		BNO055_TEMP_SOURCE_ADDR = 0X40,
 
-      /* Axis remap registers */
-      BNO055_AXIS_MAP_CONFIG_ADDR                             = 0X41,
-      BNO055_AXIS_MAP_SIGN_ADDR                               = 0X42,
+		/* Axis remap registers */
+		BNO055_AXIS_MAP_CONFIG_ADDR = 0X41,
+		BNO055_AXIS_MAP_SIGN_ADDR = 0X42,
 
-      /* SIC registers */
-      BNO055_SIC_MATRIX_0_LSB_ADDR                            = 0X43,
-      BNO055_SIC_MATRIX_0_MSB_ADDR                            = 0X44,
-      BNO055_SIC_MATRIX_1_LSB_ADDR                            = 0X45,
-      BNO055_SIC_MATRIX_1_MSB_ADDR                            = 0X46,
-      BNO055_SIC_MATRIX_2_LSB_ADDR                            = 0X47,
-      BNO055_SIC_MATRIX_2_MSB_ADDR                            = 0X48,
-      BNO055_SIC_MATRIX_3_LSB_ADDR                            = 0X49,
-      BNO055_SIC_MATRIX_3_MSB_ADDR                            = 0X4A,
-      BNO055_SIC_MATRIX_4_LSB_ADDR                            = 0X4B,
-      BNO055_SIC_MATRIX_4_MSB_ADDR                            = 0X4C,
-      BNO055_SIC_MATRIX_5_LSB_ADDR                            = 0X4D,
-      BNO055_SIC_MATRIX_5_MSB_ADDR                            = 0X4E,
-      BNO055_SIC_MATRIX_6_LSB_ADDR                            = 0X4F,
-      BNO055_SIC_MATRIX_6_MSB_ADDR                            = 0X50,
-      BNO055_SIC_MATRIX_7_LSB_ADDR                            = 0X51,
-      BNO055_SIC_MATRIX_7_MSB_ADDR                            = 0X52,
-      BNO055_SIC_MATRIX_8_LSB_ADDR                            = 0X53,
-      BNO055_SIC_MATRIX_8_MSB_ADDR                            = 0X54,
+		/* SIC registers */
+		BNO055_SIC_MATRIX_0_LSB_ADDR = 0X43,
+		BNO055_SIC_MATRIX_0_MSB_ADDR = 0X44,
+		BNO055_SIC_MATRIX_1_LSB_ADDR = 0X45,
+		BNO055_SIC_MATRIX_1_MSB_ADDR = 0X46,
+		BNO055_SIC_MATRIX_2_LSB_ADDR = 0X47,
+		BNO055_SIC_MATRIX_2_MSB_ADDR = 0X48,
+		BNO055_SIC_MATRIX_3_LSB_ADDR = 0X49,
+		BNO055_SIC_MATRIX_3_MSB_ADDR = 0X4A,
+		BNO055_SIC_MATRIX_4_LSB_ADDR = 0X4B,
+		BNO055_SIC_MATRIX_4_MSB_ADDR = 0X4C,
+		BNO055_SIC_MATRIX_5_LSB_ADDR = 0X4D,
+		BNO055_SIC_MATRIX_5_MSB_ADDR = 0X4E,
+		BNO055_SIC_MATRIX_6_LSB_ADDR = 0X4F,
+		BNO055_SIC_MATRIX_6_MSB_ADDR = 0X50,
+		BNO055_SIC_MATRIX_7_LSB_ADDR = 0X51,
+		BNO055_SIC_MATRIX_7_MSB_ADDR = 0X52,
+		BNO055_SIC_MATRIX_8_LSB_ADDR = 0X53,
+		BNO055_SIC_MATRIX_8_MSB_ADDR = 0X54,
 
-      /* Accelerometer Offset registers */
-      ACCEL_OFFSET_X_LSB_ADDR                                 = 0X55,
-      ACCEL_OFFSET_X_MSB_ADDR                                 = 0X56,
-      ACCEL_OFFSET_Y_LSB_ADDR                                 = 0X57,
-      ACCEL_OFFSET_Y_MSB_ADDR                                 = 0X58,
-      ACCEL_OFFSET_Z_LSB_ADDR                                 = 0X59,
-      ACCEL_OFFSET_Z_MSB_ADDR                                 = 0X5A,
+		/* Accelerometer Offset registers */
+		ACCEL_OFFSET_X_LSB_ADDR = 0X55,
+		ACCEL_OFFSET_X_MSB_ADDR = 0X56,
+		ACCEL_OFFSET_Y_LSB_ADDR = 0X57,
+		ACCEL_OFFSET_Y_MSB_ADDR = 0X58,
+		ACCEL_OFFSET_Z_LSB_ADDR = 0X59,
+		ACCEL_OFFSET_Z_MSB_ADDR = 0X5A,
 
-      /* Magnetometer Offset registers */
-      MAG_OFFSET_X_LSB_ADDR                                   = 0X5B,
-      MAG_OFFSET_X_MSB_ADDR                                   = 0X5C,
-      MAG_OFFSET_Y_LSB_ADDR                                   = 0X5D,
-      MAG_OFFSET_Y_MSB_ADDR                                   = 0X5E,
-      MAG_OFFSET_Z_LSB_ADDR                                   = 0X5F,
-      MAG_OFFSET_Z_MSB_ADDR                                   = 0X60,
+		/* Magnetometer Offset registers */
+		MAG_OFFSET_X_LSB_ADDR = 0X5B,
+		MAG_OFFSET_X_MSB_ADDR = 0X5C,
+		MAG_OFFSET_Y_LSB_ADDR = 0X5D,
+		MAG_OFFSET_Y_MSB_ADDR = 0X5E,
+		MAG_OFFSET_Z_LSB_ADDR = 0X5F,
+		MAG_OFFSET_Z_MSB_ADDR = 0X60,
 
-      /* Gyroscope Offset register s*/
-      GYRO_OFFSET_X_LSB_ADDR                                  = 0X61,
-      GYRO_OFFSET_X_MSB_ADDR                                  = 0X62,
-      GYRO_OFFSET_Y_LSB_ADDR                                  = 0X63,
-      GYRO_OFFSET_Y_MSB_ADDR                                  = 0X64,
-      GYRO_OFFSET_Z_LSB_ADDR                                  = 0X65,
-      GYRO_OFFSET_Z_MSB_ADDR                                  = 0X66,
+		/* Gyroscope Offset register s*/
+		GYRO_OFFSET_X_LSB_ADDR = 0X61,
+		GYRO_OFFSET_X_MSB_ADDR = 0X62,
+		GYRO_OFFSET_Y_LSB_ADDR = 0X63,
+		GYRO_OFFSET_Y_MSB_ADDR = 0X64,
+		GYRO_OFFSET_Z_LSB_ADDR = 0X65,
+		GYRO_OFFSET_Z_MSB_ADDR = 0X66,
 
-      /* Radius registers */
-      ACCEL_RADIUS_LSB_ADDR                                   = 0X67,
-      ACCEL_RADIUS_MSB_ADDR                                   = 0X68,
-      MAG_RADIUS_LSB_ADDR                                     = 0X69,
-      MAG_RADIUS_MSB_ADDR                                     = 0X6A
-    } adafruit_bno055_reg_t;
+		/* Radius registers */
+		ACCEL_RADIUS_LSB_ADDR = 0X67,
+		ACCEL_RADIUS_MSB_ADDR = 0X68,
+		MAG_RADIUS_LSB_ADDR = 0X69,
+		MAG_RADIUS_MSB_ADDR = 0X6A
+	} adafruit_bno055_reg_t;
 
-    typedef enum
-    {
-      POWER_MODE_NORMAL                                       = 0X00,
-      POWER_MODE_LOWPOWER                                     = 0X01,
-      POWER_MODE_SUSPEND                                      = 0X02
-    } adafruit_bno055_powermode_t;
+	typedef enum
+	{
+		POWER_MODE_NORMAL = 0X00,
+		POWER_MODE_LOWPOWER = 0X01,
+		POWER_MODE_SUSPEND = 0X02
+	} adafruit_bno055_powermode_t;
 
-    typedef enum
-    {
-      /* Operation mode settings*/
-      OPERATION_MODE_CONFIG                                   = 0X00,
-      OPERATION_MODE_ACCONLY                                  = 0X01,
-      OPERATION_MODE_MAGONLY                                  = 0X02,
-      OPERATION_MODE_GYRONLY                                  = 0X03,
-      OPERATION_MODE_ACCMAG                                   = 0X04,
-      OPERATION_MODE_ACCGYRO                                  = 0X05,
-      OPERATION_MODE_MAGGYRO                                  = 0X06,
-      OPERATION_MODE_AMG                                      = 0X07,
-      OPERATION_MODE_IMUPLUS                                  = 0X08,
-      OPERATION_MODE_COMPASS                                  = 0X09,
-      OPERATION_MODE_M4G                                      = 0X0A,
-      OPERATION_MODE_NDOF_FMC_OFF                             = 0X0B,
-      OPERATION_MODE_NDOF                                     = 0X0C
-    } adafruit_bno055_opmode_t;
+	typedef enum
+	{
+		/* Operation mode settings*/
+		OPERATION_MODE_CONFIG = 0X00,
+		OPERATION_MODE_ACCONLY = 0X01,
+		OPERATION_MODE_MAGONLY = 0X02,
+		OPERATION_MODE_GYRONLY = 0X03,
+		OPERATION_MODE_ACCMAG = 0X04,
+		OPERATION_MODE_ACCGYRO = 0X05,
+		OPERATION_MODE_MAGGYRO = 0X06,
+		OPERATION_MODE_AMG = 0X07,
+		OPERATION_MODE_IMUPLUS = 0X08,
+		OPERATION_MODE_COMPASS = 0X09,
+		OPERATION_MODE_M4G = 0X0A,
+		OPERATION_MODE_NDOF_FMC_OFF = 0X0B,
+		OPERATION_MODE_NDOF = 0X0C
+	} adafruit_bno055_opmode_t;
 
-    typedef struct
-    {
-      uint8_t  accel_rev;
-      uint8_t  mag_rev;
-      uint8_t  gyro_rev;
-      uint16_t sw_rev;
-      uint8_t  bl_rev;
-    } adafruit_bno055_rev_info_t;
+	typedef struct
+	{
+		uint8_t  accel_rev;
+		uint8_t  mag_rev;
+		uint8_t  gyro_rev;
+		uint16_t sw_rev;
+		uint8_t  bl_rev;
+	} adafruit_bno055_rev_info_t;
 
-    typedef enum
-    {
-      VECTOR_ACCELEROMETER = BNO055_ACCEL_DATA_X_LSB_ADDR,
-      VECTOR_MAGNETOMETER  = BNO055_MAG_DATA_X_LSB_ADDR,
-      VECTOR_GYROSCOPE     = BNO055_GYRO_DATA_X_LSB_ADDR,
-      VECTOR_EULER         = BNO055_EULER_H_LSB_ADDR,
-      VECTOR_LINEARACCEL   = BNO055_LINEAR_ACCEL_DATA_X_LSB_ADDR,
-      VECTOR_GRAVITY       = BNO055_GRAVITY_DATA_X_LSB_ADDR
-    } adafruit_vector_type_t;
+	typedef enum
+	{
+		VECTOR_ACCELEROMETER = BNO055_ACCEL_DATA_X_LSB_ADDR,
+		VECTOR_MAGNETOMETER = BNO055_MAG_DATA_X_LSB_ADDR,
+		VECTOR_GYROSCOPE = BNO055_GYRO_DATA_X_LSB_ADDR,
+		VECTOR_EULER = BNO055_EULER_H_LSB_ADDR,
+		VECTOR_LINEARACCEL = BNO055_LINEAR_ACCEL_DATA_X_LSB_ADDR,
+		VECTOR_GRAVITY = BNO055_GRAVITY_DATA_X_LSB_ADDR
+	} adafruit_vector_type_t;
 
-    Adafruit_BNO055 ( int32_t sensorID = -1, uint8_t address = BNO055_ADDRESS_A );
 
-    bool  begin               ( adafruit_bno055_opmode_t mode = OPERATION_MODE_NDOF );
-    void  setMode             ( adafruit_bno055_opmode_t mode );
-    void  getRevInfo          ( adafruit_bno055_rev_info_t* );
-    void  displayRevInfo      ( void );
-    void  setExtCrystalUse    ( boolean usextal );
-    void  getSystemStatus     ( uint8_t *system_status,
-                                uint8_t *self_test_result,
-                                uint8_t *system_error);
-    void  displaySystemStatus ( void );
-    void  getCalibration      ( uint8_t* system, uint8_t* gyro, uint8_t* accel, uint8_t* mag);
 
-    imu::Vector<3>  getVector ( adafruit_vector_type_t vector_type );
-    imu::Quaternion getQuat   ( void );
-    int8_t          getTemp   ( void );
+	Adafruit_BNO055(int32_t sensorID = -1, uint8_t address = BNO055_ADDRESS_A);
 
-    /* Adafruit_Sensor implementation */
-    bool  getEvent  ( sensors_event_t* );
-    void  getSensor ( sensor_t* );
+	bool  begin(adafruit_bno055_opmode_t mode = OPERATION_MODE_NDOF);
+	void  setMode(adafruit_bno055_opmode_t mode);
+	void  getRevInfo(adafruit_bno055_rev_info_t*);
+	void  displayRevInfo(void);
+	void  setExtCrystalUse(boolean usextal);
+	void  getSystemStatus(uint8_t *system_status,
+		uint8_t *self_test_result,
+		uint8_t *system_error);
+	void  displaySystemStatus(void);
+	void  getCalibration(uint8_t* system, uint8_t* gyro, uint8_t* accel, uint8_t* mag);
 
-  private:
-    byte  read8   ( adafruit_bno055_reg_t );
-    bool  readLen ( adafruit_bno055_reg_t, byte* buffer, uint8_t len );
-    bool  write8  ( adafruit_bno055_reg_t, byte value );
+	imu::Vector<3>  getVector(adafruit_vector_type_t vector_type);
+	imu::Quaternion getQuat(void);
+	int8_t          getTemp(void);
 
-    uint8_t _address;
-    int32_t _sensorID;
-    adafruit_bno055_opmode_t _mode;
+	/* Adafruit_Sensor implementation */
+	bool  getEvent(sensors_event_t*);
+	void  getSensor(sensor_t*);
+
+	/* Functions to deal with raw calibration data */
+	bool  getSensorOffsets(int8_t* calibData);
+	bool  getSensorOffsets(adafruit_bno055_offsets_t &offsets_type);
+	void  setSensorOffsets(const int8_t* calibData);
+	void  setSensorOffsets(const adafruit_bno055_offsets_t &offsets_type);
+	bool  isFullyCalibrated(void);
+
+private:
+	byte  read8(adafruit_bno055_reg_t);
+	bool  readLen(adafruit_bno055_reg_t, byte* buffer, uint8_t len);
+	bool  write8(adafruit_bno055_reg_t, byte value);
+
+	uint8_t _address;
+	int32_t _sensorID;
+	adafruit_bno055_opmode_t _mode;
 };
 
 #endif

--- a/examples/restore_offsets/restore_offsets.ino
+++ b/examples/restore_offsets/restore_offsets.ino
@@ -177,11 +177,11 @@ void setup(void)
 	bno.getSensor(&sensor);
 	if (bnoID != sensor.sensor_id)
 	{
-		Serial.println("No Calibration Data for this sensor exists in EEPROM");
+		Serial.println("\nNo Calibration Data for this sensor exists in EEPROM");
 	}
 	else
 	{
-		Serial.println("Found Calibration for this sensor in EEPROM.");
+		Serial.println("\nFound Calibration for this sensor in EEPROM.");
 		eeAddress += sizeof(long);
 		EEPROM.get(eeAddress, calibrationData);
 
@@ -241,8 +241,9 @@ void setup(void)
 	Serial.println("\nFully calibrated!");
 	Serial.println("--------------------------------");
 	Serial.println("Calibration Results: ");
-	bno.getSensorOffsets(calibrationData);
-	displaySensorOffsets(calibrationData);
+	adafruit_bno055_offsets_t newCalib;
+	bno.getSensorOffsets(newCalib);
+	displaySensorOffsets(newCalib);
     
     Serial.println("\n\nStoring calibration data to EEPROM...");
 
@@ -253,10 +254,11 @@ void setup(void)
 	EEPROM.put(eeAddress, bnoID);
 
 	eeAddress += sizeof(long);
-	EEPROM.put(eeAddress, calibrationData);
-	Serial.println("Data stored to EEPROM.\n");
+	EEPROM.put(eeAddress, newCalib);
+	Serial.println("Data stored to EEPROM.");
     
 	Serial.println("\n--------------------------------\n");
+	delay(500);
 }
 
 void loop() {

--- a/examples/restore_offsets/restore_offsets.ino
+++ b/examples/restore_offsets/restore_offsets.ino
@@ -1,0 +1,262 @@
+#include <Wire.h>
+#include <Adafruit_Sensor.h>
+#include <Adafruit_BNO055.h>
+#include <utility/imumaths.h>
+#include <EEPROM.h>
+
+/* This driver uses the Adafruit unified sensor library (Adafruit_Sensor),
+   which provides a common 'type' for sensor data and some helper functions.
+
+   To use this driver you will also need to download the Adafruit_Sensor
+   library and include it in your libraries folder.
+
+   You should also assign a unique ID to this sensor for use with
+   the Adafruit Sensor API so that you can identify this particular
+   sensor in any data logs, etc.  To assign a unique ID, simply
+   provide an appropriate value in the constructor below (12345
+   is used by default in this example).
+
+   Connections
+   ===========
+   Connect SCL to analog 5
+   Connect SDA to analog 4
+   Connect VDD to 3-5V DC
+   Connect GROUND to common ground
+
+   History
+   =======
+   2015/MAR/03  - First release (KTOWN)
+   2015/AUG/27  - Added calibration and system status helpers
+   2015/NOV/13  - Added calibration save and restore
+   */
+
+/* Set the delay between fresh samples */
+#define BNO055_SAMPLERATE_DELAY_MS (100)
+
+Adafruit_BNO055 bno = Adafruit_BNO055(55);
+
+/**************************************************************************/
+/*
+	Displays some basic information on this sensor from the unified
+	sensor API sensor_t type (see Adafruit_Sensor for more information)
+	*/
+/**************************************************************************/
+void displaySensorDetails(void)
+{
+	sensor_t sensor;
+	bno.getSensor(&sensor);
+	Serial.println("------------------------------------");
+	Serial.print("Sensor:       "); Serial.println(sensor.name);
+	Serial.print("Driver Ver:   "); Serial.println(sensor.version);
+	Serial.print("Unique ID:    "); Serial.println(sensor.sensor_id);
+	Serial.print("Max Value:    "); Serial.print(sensor.max_value); Serial.println(" xxx");
+	Serial.print("Min Value:    "); Serial.print(sensor.min_value); Serial.println(" xxx");
+	Serial.print("Resolution:   "); Serial.print(sensor.resolution); Serial.println(" xxx");
+	Serial.println("------------------------------------");
+	Serial.println("");
+	delay(500);
+}
+
+/**************************************************************************/
+/*
+	Display some basic info about the sensor status
+	*/
+/**************************************************************************/
+void displaySensorStatus(void)
+{
+	/* Get the system status values (mostly for debugging purposes) */
+	uint8_t system_status, self_test_results, system_error;
+	system_status = self_test_results = system_error = 0;
+	bno.getSystemStatus(&system_status, &self_test_results, &system_error);
+
+	/* Display the results in the Serial Monitor */
+	Serial.println("");
+	Serial.print("System Status: 0x");
+	Serial.println(system_status, HEX);
+	Serial.print("Self Test:     0x");
+	Serial.println(self_test_results, HEX);
+	Serial.print("System Error:  0x");
+	Serial.println(system_error, HEX);
+	Serial.println("");
+	delay(500);
+}
+
+/**************************************************************************/
+/*
+	Display sensor calibration status
+	*/
+/**************************************************************************/
+void displayCalStatus(void)
+{
+	/* Get the four calibration values (0..3) */
+	/* Any sensor data reporting 0 should be ignored, */
+	/* 3 means 'fully calibrated" */
+	uint8_t system, gyro, accel, mag;
+	system = gyro = accel = mag = 0;
+	bno.getCalibration(&system, &gyro, &accel, &mag);
+
+	/* The data should be ignored until the system calibration is > 0 */
+	Serial.print("\t");
+	if (!system)
+	{
+		Serial.print("! ");
+	}
+
+	/* Display the individual values */
+	Serial.print("Sys:");
+	Serial.print(system, DEC);
+	Serial.print(" G:");
+	Serial.print(gyro, DEC);
+	Serial.print(" A:");
+	Serial.print(accel, DEC);
+	Serial.print(" M:");
+	Serial.print(mag, DEC);
+}
+
+/**************************************************************************/
+/*
+	Display the raw calibration offset and radius data
+	*/
+/**************************************************************************/
+void displaySensorOffsets(const adafruit_bno055_offsets_t &calibData)
+{
+	Serial.print("Accelerometer: ");
+	Serial.print(calibData.accel_offset_x); Serial.print(" ");
+	Serial.print(calibData.accel_offset_y); Serial.print(" ");
+	Serial.print(calibData.accel_offset_z); Serial.print(" ");
+
+	Serial.print("\nGyro: ");
+	Serial.print(calibData.gyro_offset_x); Serial.print(" ");
+	Serial.print(calibData.gyro_offset_y); Serial.print(" ");
+	Serial.print(calibData.gyro_offset_z); Serial.print(" ");
+
+	Serial.print("\nMag: ");
+	Serial.print(calibData.mag_offset_x); Serial.print(" ");
+	Serial.print(calibData.mag_offset_y); Serial.print(" ");
+	Serial.print(calibData.mag_offset_z); Serial.print(" ");
+
+	Serial.print("\nAccel Radius: ");
+	Serial.print(calibData.accel_radius);
+
+	Serial.print("\nMag Radius: ");
+	Serial.print(calibData.mag_radius);
+}
+
+
+/**************************************************************************/
+/*
+	Arduino setup function (automatically called at startup)
+	*/
+/**************************************************************************/
+void setup(void)
+{
+	Serial.begin(115200);
+	Serial.println("Orientation Sensor Test"); Serial.println("");
+
+	/* Initialise the sensor */
+	if (!bno.begin())
+	{
+		/* There was a problem detecting the BNO055 ... check your connections */
+		Serial.print("Ooops, no BNO055 detected ... Check your wiring or I2C ADDR!");
+		while (1);
+	}
+
+	int eeAddress = 0;
+	long bnoID;
+	bool foundCalib = false;
+
+	EEPROM.get(eeAddress, bnoID);
+
+	adafruit_bno055_offsets_t calibrationData;
+	sensor_t sensor;
+
+	/*
+	*  Look for the sensor's unique ID at the beginning oF EEPROM.
+	*  This isn't foolproof, but it's better than nothing.
+	*/
+	bno.getSensor(&sensor);
+	if (bnoID != sensor.sensor_id)
+	{
+		Serial.println("No Calibration Data for this sensor exists in EEPROM");
+	}
+	else
+	{
+		foundCalib = true;
+		Serial.println("Found Calibration for this sensor in EEPROM.");
+		eeAddress += sizeof(long);
+		EEPROM.get(eeAddress, calibrationData);
+
+		displaySensorOffsets(calibrationData);
+
+		Serial.println("\n\nRestoring Calibration data to the BNO055...");
+		bno.setSensorOffsets(calibrationData);
+
+		Serial.println("\n\nCalibration data loaded into BNO055");
+	}
+
+	delay(1000);
+
+	/* Display some basic information on this sensor */
+	displaySensorDetails();
+
+	/* Optional: Display current status */
+	displaySensorStatus();
+
+	bno.setExtCrystalUse(true);
+
+	sensors_event_t event;
+	bno.getEvent(&event);
+	Serial.println("Move sensor slightly to calibrate magnetometers");
+	while (!bno.isFullyCalibrated())
+	{
+		bno.getEvent(&event);
+		delay(BNO055_SAMPLERATE_DELAY_MS);
+	}
+
+	Serial.println("\nFully calibrated!");
+	Serial.println("--------------------------------");
+	Serial.println("Calibration Results: ");
+	bno.getSensorOffsets(calibrationData);
+	displaySensorOffsets(calibrationData);
+	Serial.println("\n--------------------------------\n\n");
+
+	//if (!foundCalib){
+	Serial.println("\n\nStoring calibration data to EEPROM...");
+
+	eeAddress = 0;
+	bno.getSensor(&sensor);
+	bnoID = sensor.sensor_id;
+
+	EEPROM.put(eeAddress, bnoID);
+
+	eeAddress += sizeof(long);
+	EEPROM.put(eeAddress, calibrationData);
+	Serial.println("Data stored to EEPROM.\n");
+	//}
+}
+
+void loop() {
+	/* Get a new sensor event */
+	sensors_event_t event;
+	bno.getEvent(&event);
+
+	/* Display the floating point data */
+	Serial.print("X: ");
+	Serial.print(event.orientation.x, 4);
+	Serial.print("\tY: ");
+	Serial.print(event.orientation.y, 4);
+	Serial.print("\tZ: ");
+	Serial.print(event.orientation.z, 4);
+
+	/* Optional: Display calibration status */
+	displayCalStatus();
+
+	/* Optional: Display sensor status (debug only) */
+	//displaySensorStatus();
+
+	/* New line for the next sample */
+	Serial.println("");
+
+	/* Wait the specified delay before requesting nex data */
+	delay(BNO055_SAMPLERATE_DELAY_MS);
+}


### PR DESCRIPTION
This PR adds five new public functions to Adafruit_BNO055 and one new global data type (a struct): adafruit_bno055_offsets_t.

The functions allow users to read and write directly to and from the sensor's "OFFSET" and "RADIUS" registers.  This allows the user to save and restore previously good calibration values.

The calibration values will only be retrieved from the sensor if the sensor is "Fully Calibrated", which is when the sensor has System, Accel, Gyro, and Mag calibrations all == 3.

This commit also includes a new example program which will look in EEPROM for a saved calibration value and restore it if it exists.  Otherwise, it will wait until the user has fully calibrated the sensor at which time it will save the calibration data to EEPROM.