### PR TITLE
Fixes for matrix utility code

### DIFF
--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -59,41 +59,42 @@ public:
         {
             _cell_data[ij] = m._cell_data[ij];
         }
+        return *this;
     }
 
-    Vector<N> row_to_vector(int y)
+    Vector<N> row_to_vector(int i) const
     {
         Vector<N> ret;
-        for(int i = 0; i < N; i++)
+        for (int j = 0; j < N; j++)
         {
-            ret[i] = _cell[y*N+i];
+            ret[j] = cell(i, j);
         }
         return ret;
     }
 
-    Vector<N> col_to_vector(int x)
+    Vector<N> col_to_vector(int j) const
     {
         Vector<N> ret;
-        for(int i = 0; i < N; i++)
+        for (int i = 0; i < N; i++)
         {
-            ret[i] = _cell[i*N+x];
+            ret[i] = cell(i, j);
         }
         return ret;
     }
 
-    void vector_to_row(Vector<N> v, int row)
+    void vector_to_row(const Vector<N>& v, int i)
     {
-        for(int i = 0; i < N; i++)
+        for (int j = 0; j < N; j++)
         {
-            cell(row, i) = v(i);
+            cell(i, j) = v[j];
         }
     }
 
-    void vector_to_col(Vector<N> v, int col)
+    void vector_to_col(const Vector<N>& v, int j)
     {
-        for(int i = 0; i < N; i++)
+        for (int i = 0; i < N; i++)
         {
-            cell(i, col) = v(i);
+            cell(i, j) = v[i];
         }
     }
 

--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -155,20 +155,20 @@ public:
             Vector<N> row = row_to_vector(i);
             for (int j = 0; j < N; j++)
             {
-                ret.cell(i, j) = row.dot(m.col_to_vector(j));
+                ret(i, j) = row.dot(m.col_to_vector(j));
             }
         }
         return ret;
     }
 
-    Matrix transpose()
+    Matrix transpose() const
     {
         Matrix ret;
-        for(int x = 0; x < N; x++)
+        for (int i = 0; i < N; i++)
         {
-            for(int y = 0; y < N; y++)
+            for (int j = 0; j < N; j++)
             {
-                ret.cell(y, x) = cell(x, y);
+                ret(j, i) = cell(i, j);
             }
         }
         return ret;

--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -36,16 +36,13 @@ template <uint8_t N> class Matrix
 public:
     Matrix()
     {
-        int r = sizeof(double)*N;
         _cell = &_cell_data[0];
-        memset(_cell, 0, r*r);
+        memset(_cell, 0, N*N*sizeof(double));
     }
 
     Matrix(const Matrix &v)
     {
-        int r = sizeof(double)*N;
         _cell = &_cell_data[0];
-        memset(_cell, 0, r*r);
         for (int x = 0; x < N; x++ )
         {
             for(int y = 0; y < N; y++)

--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -147,16 +147,15 @@ public:
         return ret;
     }
 
-    Matrix operator * (Matrix m)
+    Matrix operator*(const Matrix& m) const
     {
         Matrix ret;
-        for(int x = 0; x < N; x++)
+        for (int i = 0; i < N; i++)
         {
-            for(int y = 0; y < N; y++)
+            Vector<N> row = row_to_vector(i);
+            for (int j = 0; j < N; j++)
             {
-                Vector<N> row = row_to_vector(x);
-                Vector<N> col = m.col_to_vector(y);
-                ret.cell(x, y) = row.dot(col);
+                ret.cell(i, j) = row.dot(m.col_to_vector(j));
             }
         }
         return ret;

--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -20,10 +20,8 @@
 #ifndef IMUMATH_MATRIX_HPP
 #define IMUMATH_MATRIX_HPP
 
-#include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
-#include <math.h>
 
 #include "vector.h"
 

--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -172,24 +172,22 @@ public:
         return ret;
     }
 
-    Matrix<N-1> minor_matrix(int row, int col)
+    Matrix<N-1> minor_matrix(int row, int col) const
     {
-        int colCount = 0, rowCount = 0;
         Matrix<N-1> ret;
-        for(int i = 0; i < N; i++ )
+        for (int i = 0, im = 0; i < N; i++)
         {
-            if( i != row )
+            if (i == row)
+                continue;
+
+            for (int j = 0, jm = 0; j < N; j++)
             {
-                for(int j = 0; j < N; j++ )
+                if (j != col)
                 {
-                    if( j != col )
-                    {
-                        ret(rowCount, colCount) = cell(i, j);
-                        colCount++;
-                    }
+                    ret(im, jm++) = cell(i, j);
                 }
-                rowCount++;
             }
+            im++;
         }
         return ret;
     }

--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -117,41 +117,32 @@ public:
     }
 
 
-    Matrix operator + (Matrix m)
+    Matrix operator+(const Matrix& m) const
     {
         Matrix ret;
-        for(int x = 0; x < N; x++)
+        for (int ij = 0; ij < N*N; ++ij)
         {
-            for(int y = 0; y < N; y++)
-            {
-                ret._cell[x*N+y] = _cell[x*N+y] + m._cell[x*N+y];
-            }
+            ret._cell_data[ij] = _cell_data[ij] + m._cell_data[ij];
         }
         return ret;
     }
 
-    Matrix operator - (Matrix m)
+    Matrix operator-(const Matrix& m) const
     {
         Matrix ret;
-        for(int x = 0; x < N; x++)
+        for (int ij = 0; ij < N*N; ++ij)
         {
-            for(int y = 0; y < N; y++)
-            {
-                ret._cell[x*N+y] = _cell[x*N+y] - m._cell[x*N+y];
-            }
+            ret._cell_data[ij] = _cell_data[ij] - m._cell_data[ij];
         }
         return ret;
     }
 
-    Matrix operator * (double scalar)
+    Matrix operator*(double scalar) const
     {
         Matrix ret;
-        for(int x = 0; x < N; x++)
+        for (int ij = 0; ij < N*N; ++ij)
         {
-            for(int y = 0; y < N; y++)
-            {
-                ret._cell[x*N+y] = _cell[x*N+y] * scalar;
-            }
+            ret._cell_data[ij] = _cell_data[ij] * scalar;
         }
         return ret;
     }

--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -192,7 +192,7 @@ public:
         return ret;
     }
 
-    double determinant()
+    double determinant() const
     {
         if(N == 1)
             return cell(0, 0);
@@ -206,19 +206,18 @@ public:
         return det;
     }
 
-    Matrix invert()
+    Matrix invert() const
     {
         Matrix ret;
         float det = determinant();
 
-        for(int x = 0; x < N; x++)
+        for (int i = 0; i < N; i++)
         {
-            for(int y = 0; y < N; y++)
+            for (int j = 0; j < N; j++)
             {
-                Matrix<N-1> minor = minor_matrix(y, x);
-                ret(x, y) = det*minor.determinant();
-                if( (x+y)%2 == 1)
-                    ret(x, y) = -ret(x, y);
+                ret(i, j) = minor_matrix(j, i).determinant() / det;
+                if ((i+j)%2 == 1)
+                    ret(i, j) = -ret(i, j);
             }
         }
         return ret;

--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -25,6 +25,8 @@
 #include <stdint.h>
 #include <math.h>
 
+#include "vector.h"
+
 namespace imu
 {
 

--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -36,13 +36,11 @@ template <uint8_t N> class Matrix
 public:
     Matrix()
     {
-        _cell = &_cell_data[0];
-        memset(_cell, 0, N*N*sizeof(double));
+        memset(_cell_data, 0, N*N*sizeof(double));
     }
 
     Matrix(const Matrix &m)
     {
-        _cell = &_cell_data[0];
         for (int ij = 0; ij < N*N; ++ij)
         {
             _cell_data[ij] = m._cell_data[ij];
@@ -229,7 +227,6 @@ public:
     }
 
 private:
-    double* _cell;
     double  _cell_data[N*N];
 };
 

--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -40,15 +40,12 @@ public:
         memset(_cell, 0, N*N*sizeof(double));
     }
 
-    Matrix(const Matrix &v)
+    Matrix(const Matrix &m)
     {
         _cell = &_cell_data[0];
-        for (int x = 0; x < N; x++ )
+        for (int ij = 0; ij < N*N; ++ij)
         {
-            for(int y = 0; y < N; y++)
-            {
-                _cell[x*N+y] = v._cell[x*N+y];
-            }
+            _cell_data[ij] = m._cell_data[ij];
         }
     }
 
@@ -56,14 +53,11 @@ public:
     {
     }
 
-    void operator = (Matrix m)
+    Matrix& operator=(const Matrix& m)
     {
-        for(int x = 0; x < N; x++)
+        for (int ij = 0; ij < N*N; ++ij)
         {
-            for(int y = 0; y < N; y++)
-            {
-                cell(x, y) = m.cell(x, y);
-            }
+            _cell_data[ij] = m._cell_data[ij];
         }
     }
 

--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -192,15 +192,10 @@ public:
 
     double determinant() const
     {
-        if(N == 1)
-            return cell(0, 0);
-
-        float det = 0.0;
-        for(int i = 0; i < N; i++ )
-        {
-            Matrix<N-1> minor = minor_matrix(0, i);
-            det += (i%2==1?-1.0:1.0) * cell(0, i) * minor.determinant();
-        }
+        // specialization for N == 1 given below this class
+        double det = 0.0, sign = 1.0;
+        for (int i = 0; i < N; ++i, sign = -sign)
+            det += sign * cell(0, i) * minor_matrix(0, i).determinant();
         return det;
     }
 
@@ -225,6 +220,12 @@ private:
     double  _cell_data[N*N];
 };
 
+
+template<>
+inline double Matrix<1>::determinant() const
+{
+    return cell(0, 0);
+}
 
 };
 

--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -103,14 +103,22 @@ public:
         }
     }
 
-    double& operator ()(int x, int y)
+    double operator()(int i, int j) const
     {
-        return _cell[x*N+y];
+        return cell(i, j);
+    }
+    double& operator()(int i, int j)
+    {
+        return cell(i, j);
     }
 
-    double& cell(int x, int y)
+    double cell(int i, int j) const
     {
-        return _cell[x*N+y];
+        return _cell_data[i*N+j];
+    }
+    double& cell(int i, int j)
+    {
+        return _cell_data[i*N+j];
     }
 
 


### PR DESCRIPTION
This pull request contains several fixes for the matrix utility code in the BNO055 driver. It fixes the following problems:
*) the constructors zero out too much data, writing beyond the end of the matrix data array.
*) the _cell member variable is unnecessary, and can be removed
*) the calculation of minors was incorrect, and read beyond the end of the matrix data array.
*) the calculation of the inverse was incorrect
*) combinatorial explosion in the determinant function, since the compiler could not determine that for N==1, the determinants for the minors need not be calculated,

In addition, member functions that do not modify the matrix have been marked as const, element access functions for constant matrices have been added, and matrices and vectors are now passed by constant reference instead of by value.