### PR TITLE
Cleanup of quaternion code

### DIFF
--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -202,7 +202,7 @@ public:
     Matrix invert() const
     {
         Matrix ret;
-        float det = determinant();
+        double det = determinant();
 
         for (int i = 0; i < N; i++)
         {
@@ -217,7 +217,7 @@ public:
     }
 
 private:
-    double  _cell_data[N*N];
+    double _cell_data[N*N];
 };
 
 

--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -216,6 +216,14 @@ public:
         return ret;
     }
 
+    double trace() const
+    {
+        double tr = 0.0;
+        for (int i = 0; i < N; ++i)
+            tr += cell(i, i);
+        return tr;
+    }
+
 private:
     double _cell_data[N*N];
 };

--- a/utility/quaternion.h
+++ b/utility/quaternion.h
@@ -126,11 +126,11 @@ public:
         _z = axis.z() * sht;
     }
 
-    void fromMatrix(Matrix<3> m)
+    void fromMatrix(const Matrix<3>& m)
     {
-        float tr = m(0, 0) + m(1, 1) + m(2, 2);
+        double tr = m.trace();
 
-        float S = 0.0;
+        double S;
         if (tr > 0)
         {
             S = sqrt(tr+1.0) * 2;
@@ -139,7 +139,7 @@ public:
             _y = (m(0, 2) - m(2, 0)) / S;
             _z = (m(1, 0) - m(0, 1)) / S;
         }
-        else if ((m(0, 0) < m(1, 1))&(m(0, 0) < m(2, 2)))
+        else if (m(0, 0) > m(1, 1) && m(0, 0) > m(2, 2))
         {
             S = sqrt(1.0 + m(0, 0) - m(1, 1) - m(2, 2)) * 2;
             _w = (m(2, 1) - m(1, 2)) / S;
@@ -147,7 +147,7 @@ public:
             _y = (m(0, 1) + m(1, 0)) / S;
             _z = (m(0, 2) + m(2, 0)) / S;
         }
-        else if (m(1, 1) < m(2, 2))
+        else if (m(1, 1) > m(2, 2))
         {
             S = sqrt(1.0 + m(1, 1) - m(0, 0) - m(2, 2)) * 2;
             _w = (m(0, 2) - m(2, 0)) / S;

--- a/utility/quaternion.h
+++ b/utility/quaternion.h
@@ -35,27 +35,13 @@ namespace imu
 class Quaternion
 {
 public:
-    Quaternion()
-    {
-        _w = 1.0;
-        _x = _y = _z = 0.0;
-    }
+    Quaternion(): _w(1.0), _x(0.0), _y(0.0), _z(0.0) {}
 
-    Quaternion(double iw, double ix, double iy, double iz)
-    {
-        _w = iw;
-        _x = ix;
-        _y = iy;
-        _z = iz;
-    }
+    Quaternion(double w, double x, double y, double z):
+        _w(w), _x(x), _y(y), _z(z) {}
 
-    Quaternion(double w, Vector<3> vec)
-    {
-        _w = w;
-        _x = vec.x();
-        _y = vec.y();
-        _z = vec.z();
-    }
+    Quaternion(double w, Vector<3> vec):
+        _w(w), _x(vec.x()), _y(vec.y()), _z(vec.z()) {}
 
     double& w()
     {
@@ -243,7 +229,7 @@ public:
     }
 
 
-    const Quaternion operator*(const Quaternion& q) const
+    Quaternion operator*(const Quaternion& q) const
     {
         return Quaternion(
             _w*q._w - _x*q._x - _y*q._y - _z*q._z,
@@ -253,27 +239,27 @@ public:
         );
     }
 
-    const Quaternion operator+(const Quaternion& q) const
+    Quaternion operator+(const Quaternion& q) const
     {
         return Quaternion(_w + q._w, _x + q._x, _y + q._y, _z + q._z);
     }
 
-    const Quaternion operator-(const Quaternion& q) const
+    Quaternion operator-(const Quaternion& q) const
     {
         return Quaternion(_w - q._w, _x - q._x, _y - q._y, _z - q._z);
     }
 
-    const Quaternion operator/(double scalar) const
+    Quaternion operator/(double scalar) const
     {
         return Quaternion(_w / scalar, _x / scalar, _y / scalar, _z / scalar);
     }
 
-    const Quaternion operator*(double scalar) const
+    Quaternion operator*(double scalar) const
     {
         return scale(scalar);
     }
 
-    const Quaternion scale(double scalar) const
+    Quaternion scale(double scalar) const
     {
         return Quaternion(_w * scalar, _x * scalar, _y * scalar, _z * scalar);
     }

--- a/utility/quaternion.h
+++ b/utility/quaternion.h
@@ -157,17 +157,17 @@ public:
     Matrix<3> toMatrix() const
     {
         Matrix<3> ret;
-        ret.cell(0, 0) = 1-(2*(_y*_y))-(2*(_z*_z));
-        ret.cell(0, 1) = (2*_x*_y)-(2*_w*_z);
-        ret.cell(0, 2) = (2*_x*_z)+(2*_w*_y);
+        ret.cell(0, 0) = 1 - 2*_y*_y - 2*_z*_z;
+        ret.cell(0, 1) = 2*_x*_y - 2*_w*_z;
+        ret.cell(0, 2) = 2*_x*_z + 2*_w*_y;
 
-        ret.cell(1, 0) = (2*_x*_y)+(2*_w*_z);
-        ret.cell(1, 1) = 1-(2*(_x*_x))-(2*(_z*_z));
-        ret.cell(1, 2) = (2*(_y*_z))-(2*(_w*_x));
+        ret.cell(1, 0) = 2*_x*_y + 2*_w*_z;
+        ret.cell(1, 1) = 1 - 2*_x*_x - 2*_z*_z;
+        ret.cell(1, 2) = 2*_y*_z - 2*_w*_x;
 
-        ret.cell(2, 0) = (2*(_x*_z))-(2*_w*_y);
-        ret.cell(2, 1) = (2*_y*_z)+(2*_w*_x);
-        ret.cell(2, 2) = 1-(2*(_x*_x))-(2*(_y*_y));
+        ret.cell(2, 0) = 2*_x*_z - 2*_w*_y;
+        ret.cell(2, 1) = 2*_y*_z + 2*_w*_x;
+        ret.cell(2, 2) = 1 - 2*_x*_x - 2*_y*_y;
         return ret;
     }
 

--- a/utility/quaternion.h
+++ b/utility/quaternion.h
@@ -142,10 +142,10 @@ public:
         }
     }
 
-    void toAxisAngle(Vector<3>& axis, float& angle) const
+    void toAxisAngle(Vector<3>& axis, double& angle) const
     {
-        float sqw = sqrt(1-_w*_w);
-        if(sqw == 0) //it's a singularity and divide by zero, avoid
+        double sqw = sqrt(1-_w*_w);
+        if (sqw == 0) //it's a singularity and divide by zero, avoid
             return;
 
         angle = 2 * acos(_w);
@@ -198,7 +198,7 @@ public:
         return ret;
     }
 
-    Vector<3> toAngularVelocity(float dt) const
+    Vector<3> toAngularVelocity(double dt) const
     {
         Vector<3> ret;
         Quaternion one(1.0, 0.0, 0.0, 0.0);

--- a/utility/quaternion.h
+++ b/utility/quaternion.h
@@ -32,8 +32,6 @@
 namespace imu
 {
 
-
-
 class Quaternion
 {
 public:
@@ -105,15 +103,9 @@ public:
         *this = this->scale(1/mag);
     }
 
-
-    Quaternion conjugate() const
+    const Quaternion conjugate() const
     {
-        Quaternion q;
-        q.w() = _w;
-        q.x() = -_x;
-        q.y() = -_y;
-        q.z() = -_z;
-        return q;
+        return Quaternion(_w, -_x, -_y, -_z);
     }
 
     void fromAxisAngle(Vector<3> axis, double theta)
@@ -251,71 +243,45 @@ public:
     }
 
 
-    Quaternion operator * (Quaternion q) const
+    const Quaternion operator*(const Quaternion& q) const
     {
-        Quaternion ret;
-        ret._w = ((_w*q._w) - (_x*q._x) - (_y*q._y) - (_z*q._z));
-        ret._x = ((_w*q._x) + (_x*q._w) + (_y*q._z) - (_z*q._y));
-        ret._y = ((_w*q._y) - (_x*q._z) + (_y*q._w) + (_z*q._x));
-        ret._z = ((_w*q._z) + (_x*q._y) - (_y*q._x) + (_z*q._w));
-        return ret;
+        return Quaternion(
+            _w*q._w - _x*q._x - _y*q._y - _z*q._z,
+            _w*q._x + _x*q._w + _y*q._z - _z*q._y,
+            _w*q._y - _x*q._z + _y*q._w + _z*q._x,
+            _w*q._z + _x*q._y - _y*q._x + _z*q._w
+        );
     }
 
-    Quaternion operator + (Quaternion q) const
+    const Quaternion operator+(const Quaternion& q) const
     {
-        Quaternion ret;
-        ret._w = _w + q._w;
-        ret._x = _x + q._x;
-        ret._y = _y + q._y;
-        ret._z = _z + q._z;
-        return ret;
+        return Quaternion(_w + q._w, _x + q._x, _y + q._y, _z + q._z);
     }
 
-    Quaternion operator - (Quaternion q) const
+    const Quaternion operator-(const Quaternion& q) const
     {
-        Quaternion ret;
-        ret._w = _w - q._w;
-        ret._x = _x - q._x;
-        ret._y = _y - q._y;
-        ret._z = _z - q._z;
-        return ret;
+        return Quaternion(_w - q._w, _x - q._x, _y - q._y, _z - q._z);
     }
 
-    Quaternion operator / (float scalar) const
+    const Quaternion operator/(double scalar) const
     {
-        Quaternion ret;
-        ret._w = this->_w/scalar;
-        ret._x = this->_x/scalar;
-        ret._y = this->_y/scalar;
-        ret._z = this->_z/scalar;
-        return ret;
+        return Quaternion(_w / scalar, _x / scalar, _y / scalar, _z / scalar);
     }
 
-    Quaternion operator * (float scalar) const
+    const Quaternion operator*(double scalar) const
     {
-        Quaternion ret;
-        ret._w = this->_w*scalar;
-        ret._x = this->_x*scalar;
-        ret._y = this->_y*scalar;
-        ret._z = this->_z*scalar;
-        return ret;
+        return scale(scalar);
     }
 
-    Quaternion scale(double scalar) const
+    const Quaternion scale(double scalar) const
     {
-        Quaternion ret;
-        ret._w = this->_w*scalar;
-        ret._x = this->_x*scalar;
-        ret._y = this->_y*scalar;
-        ret._z = this->_z*scalar;
-        return ret;
+        return Quaternion(_w * scalar, _x * scalar, _y * scalar, _z * scalar);
     }
 
 private:
     double _w, _x, _y, _z;
 };
 
-
-};
+} // namespace
 
 #endif

--- a/utility/quaternion.h
+++ b/utility/quaternion.h
@@ -79,8 +79,7 @@ public:
 
     double magnitude() const
     {
-        double res = (_w*_w) + (_x*_x) + (_y*_y) + (_z*_z);
-        return sqrt(res);
+        return sqrt(_w*_w + _x*_x + _y*_y + _z*_z);
     }
 
     void normalize()
@@ -89,12 +88,12 @@ public:
         *this = this->scale(1/mag);
     }
 
-    const Quaternion conjugate() const
+    Quaternion conjugate() const
     {
         return Quaternion(_w, -_x, -_y, -_z);
     }
 
-    void fromAxisAngle(Vector<3> axis, double theta)
+    void fromAxisAngle(const Vector<3>& axis, double theta)
     {
         _w = cos(theta/2);
         //only need to calculate sine of half theta once
@@ -214,18 +213,16 @@ public:
         return ret;
     }
 
-    Vector<3> rotateVector(Vector<2> v) const
+    Vector<3> rotateVector(const Vector<2>& v) const
     {
-        Vector<3> ret(v.x(), v.y(), 0.0);
-        return rotateVector(ret);
+        return rotateVector(Vector<3>(v.x(), v.y()));
     }
 
-    Vector<3> rotateVector(Vector<3> v) const
+    Vector<3> rotateVector(const Vector<3>& v) const
     {
-        Vector<3> qv(this->x(), this->y(), this->z());
-        Vector<3> t;
-        t = qv.cross(v) * 2.0;
-        return v + (t * _w) + qv.cross(t);
+        Vector<3> qv(_x, _y, _z);
+        Vector<3> t = qv.cross(v) * 2.0;
+        return v + t*_w + qv.cross(t);
     }
 
 

--- a/utility/quaternion.h
+++ b/utility/quaternion.h
@@ -26,7 +26,7 @@
 #include <stdint.h>
 #include <math.h>
 
-#include "vector.h"
+#include "matrix.h"
 
 
 namespace imu


### PR DESCRIPTION
This pull request fixes a bug in the conversion from matrices to quaternions, and polishes the quaternion class up a bit.

The bug fix is in commit e8e7977, and involves fixing a wrong test in determining the largest element of the matrix diagonal when converting a matrix with negative determinant to a quaternion. As a result of the bug fix, the square root of a negative number was taken, resulting in NaN in the result. Conversion of pure rotations (determinant == 1) was not affected.

The rest of this series simplifies a number of functions into one-liners, takes care to pass large objects by reference rather than value, and tries to preserve precision on platforms that support it by using double instead of float (the quaternion elements themselves are already stored as double).

Feel free to only pick up the bug fix in e8e7977. I think the rest is worthwhile, but it does not solve any immediate problems.