### PR TITLE
Cleanup of vector code

### DIFF
--- a/utility/matrix.h
+++ b/utility/matrix.h
@@ -3,6 +3,8 @@
     Copyright (C) 2013-2014  Samuel Cowen
     www.camelsoftware.com
 
+    Bug fixes and cleanups by Gé Vissers (gvissers@gmail.com)
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or

--- a/utility/quaternion.h
+++ b/utility/quaternion.h
@@ -3,6 +3,8 @@
     Copyright (C) 2013-2014  Samuel Cowen
 	www.camelsoftware.com
 
+    Bug fixes and cleanups by Gé Vissers (gvissers@gmail.com)
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or

--- a/utility/vector.h
+++ b/utility/vector.h
@@ -114,20 +114,12 @@ public:
         return ret;
     }
 
-    Vector cross(Vector v)
-    {
-        Vector ret;
-
-        // The cross product is only valid for vectors with 3 dimensions,
-        // with the exception of higher dimensional stuff that is beyond the intended scope of this library
-        if(N != 3)
-            return ret;
-
-        ret.p_vec[0] = (p_vec[1] * v.p_vec[2]) - (p_vec[2] * v.p_vec[1]);
-        ret.p_vec[1] = (p_vec[2] * v.p_vec[0]) - (p_vec[0] * v.p_vec[2]);
-        ret.p_vec[2] = (p_vec[0] * v.p_vec[1]) - (p_vec[1] * v.p_vec[0]);
-        return ret;
-    }
+    // The cross product is only valid for vectors with 3 dimensions,
+    // with the exception of higher dimensional stuff that is beyond
+    // the intended scope of this library.
+    // Only a definition for N==3 is given below this class, using
+    // cross() with another value for N will result in a link error.
+    Vector cross(const Vector& v) const;
 
     Vector scale(double scalar) const
     {
@@ -226,6 +218,16 @@ private:
 };
 
 
-};
+template <>
+inline Vector<3> Vector<3>::cross(const Vector& v) const
+{
+    return Vector(
+        p_vec[1] * v.p_vec[2] - p_vec[2] * v.p_vec[1],
+        p_vec[2] * v.p_vec[0] - p_vec[0] * v.p_vec[2],
+        p_vec[0] * v.p_vec[1] - p_vec[1] * v.p_vec[0]
+    );
+}
+
+} // namespace
 
 #endif

--- a/utility/vector.h
+++ b/utility/vector.h
@@ -95,7 +95,7 @@ public:
     void normalize()
     {
         double mag = magnitude();
-        if(abs(mag) <= 0.0001)
+        if (fabs(mag) <= 0.0001)
             return;
 
         int i;

--- a/utility/vector.h
+++ b/utility/vector.h
@@ -78,7 +78,7 @@ public:
 
     uint8_t n() { return N; }
 
-    double magnitude()
+    double magnitude() const
     {
         double res = 0;
         int i;
@@ -103,7 +103,7 @@ public:
             p_vec[i] = p_vec[i]/mag;
     }
 
-    double dot(Vector v)
+    double dot(const Vector& v) const
     {
         double ret = 0;
         int i;
@@ -136,7 +136,7 @@ public:
         return ret;
     }
 
-    Vector operator = (Vector v)
+    Vector& operator=(const Vector& v)
     {
         for (int x = 0; x < N; x++ )
             p_vec[x] = v.p_vec[x];
@@ -163,7 +163,7 @@ public:
         return p_vec[n];
     }
 
-    Vector operator + (Vector v) const
+    Vector operator+(const Vector& v) const
     {
         Vector ret;
         for(int i = 0; i < N; i++)
@@ -171,7 +171,7 @@ public:
         return ret;
     }
 
-    Vector operator - (Vector v) const
+    Vector operator-(const Vector& v) const
     {
         Vector ret;
         for(int i = 0; i < N; i++)

--- a/utility/vector.h
+++ b/utility/vector.h
@@ -20,7 +20,6 @@
 #ifndef IMUMATH_VECTOR_HPP
 #define IMUMATH_VECTOR_HPP
 
-#include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
 #include <math.h>

--- a/utility/vector.h
+++ b/utility/vector.h
@@ -81,9 +81,8 @@ public:
     double magnitude() const
     {
         double res = 0;
-        int i;
-        for(i = 0; i < N; i++)
-            res += (p_vec[i] * p_vec[i]);
+        for (int i = 0; i < N; i++)
+            res += p_vec[i] * p_vec[i];
 
         if(isnan(res))
             return 0;
@@ -106,8 +105,7 @@ public:
     double dot(const Vector& v) const
     {
         double ret = 0;
-        int i;
-        for(i = 0; i < N; i++)
+        for (int i = 0; i < N; i++)
             ret += p_vec[i] * v.p_vec[i];
 
         return ret;
@@ -213,7 +211,7 @@ public:
 
 
 private:
-    double  p_vec[N];
+    double p_vec[N];
 };
 
 

--- a/utility/vector.h
+++ b/utility/vector.h
@@ -84,20 +84,17 @@ public:
         for (int i = 0; i < N; i++)
             res += p_vec[i] * p_vec[i];
 
-        if(isnan(res))
-            return 0;
         return sqrt(res);
     }
 
     void normalize()
     {
         double mag = magnitude();
-        if (fabs(mag) <= 0.0001)
+        if (isnan(mag) || mag == 0.0)
             return;
 
-        int i;
-        for(i = 0; i < N; i++)
-            p_vec[i] = p_vec[i]/mag;
+        for (int i = 0; i < N; i++)
+            p_vec[i] /= mag;
     }
 
     double dot(const Vector& v) const

--- a/utility/vector.h
+++ b/utility/vector.h
@@ -86,9 +86,7 @@ public:
 
         if(isnan(res))
             return 0;
-        if((fabs(res-1)) >= 0.000001) // Avoid a sqrt if possible.
-            return sqrt(res);
-        return 1;
+        return sqrt(res);
     }
 
     void normalize()

--- a/utility/vector.h
+++ b/utility/vector.h
@@ -3,6 +3,8 @@
     Copyright (C) 2013-2014  Samuel Cowen
     www.camelsoftware.com
 
+    Bug fixes and cleanups by Gé Vissers (gvissers@gmail.com)
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or


### PR DESCRIPTION
This pull request contains a few cleanups for the vector code, mostly making methods const and passing vectors by reference. There's also a single bug fix (using integer abs() on float), but the offending test was later removed altogether since IMHO it made no sense. The final commit adds a credit line to the three files I've changed.