### PR TITLE
Use intrinsic rotations in bunny visualization

### DIFF
--- a/examples/bunny/processing/cuberotate/cuberotate.pde
+++ b/examples/bunny/processing/cuberotate/cuberotate.pde
@@ -84,9 +84,19 @@ void draw()
   translate(300, 380, 0);
   
   // Rotate shapes around the X/Y/Z axis (values in radians, 0..Pi*2)
-  rotateZ(radians(roll));
-  rotateX(radians(pitch));
-  rotateY(radians(yaw));
+  //rotateZ(radians(roll));
+  //rotateX(radians(pitch)); // extrinsic rotation
+  //rotateY(radians(yaw));
+  float c1 = cos(radians(roll));
+  float s1 = sin(radians(roll));
+  float c2 = cos(radians(pitch)); // intrinsic rotation
+  float s2 = sin(radians(pitch));
+  float c3 = cos(radians(yaw));
+  float s3 = sin(radians(yaw));
+  applyMatrix( c2*c3, s1*s3+c1*c3*s2, c3*s1*s2-c1*s3, 0,
+               -s2, c1*c2, c2*s1, 0,
+               c2*s3, c1*s2*s3-c3*s1, c1*c3+s1*s2*s3, 0,
+               0, 0, 0, 1);
 
   pushMatrix();
   noStroke();


### PR DESCRIPTION
If you run the bunny visualization and watch carefully, things aren't quite right.  Roll & pitch swap every 90 degree of heading change, because the rotations are being done about the fixed screen axes (extrinsic rotation), not the bunny's own axes (intrinsic rotation).

Put another way, consider if you're on a flight from Seattle to New York.  When the plane begins descent, that's negative pitch.  The same motion, the nose of the plane pointing downwards, doesn't magically become roll when you instead fly from Seattle to Los Angles.  But that's the way this visualizer (and many others like it) are incorrectly displaying roll, pitch and yaw.  This single rotation matrix correctly applies the rotations relative to the aircraft's frame of reference, rather than the ground's reference.