### PR TITLE
Updated preprocessor directives for Feather m0 I2C address choice

### DIFF
--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -279,7 +279,7 @@ class Adafruit_BNO055 : public Adafruit_Sensor
       VECTOR_GRAVITY       = BNO055_GRAVITY_DATA_X_LSB_ADDR
     } adafruit_vector_type_t;
 
-#ifdef ARDUINO_SAMD_ZERO
+#if defined (ARDUINO_SAMD_ZERO) && ! (ARDUINO_SAMD_FEATHER_M0)
 #error "On an arduino Zero, BNO055's ADR pin must be high. Fix that, then delete this line."
     Adafruit_BNO055 ( int32_t sensorID = -1, uint8_t address = BNO055_ADDRESS_B );
 #else


### PR DESCRIPTION
Modified the preprocessor ifdefs for I2C address choice to exclude
feather m0 boards from arduino zero error, and leave the I2C address as
the default for feathers.

See this thread on the adafruit forums:
http://forums.adafruit.com/viewtopic.php?f=19&t=95132&p=477603&hilit=bno055+feather

As the feather has the same processor as the zero, and seems to trigger
on the ifdef ARDUINO_SAMD_ZERO this directive would trigger for
that board also. However it is the Zero's debug chip that requires the
address change, not the processor. Confirmed this code as working on my
feather m0.