### PR TITLE
Enable the axis remapping functionality already present in begin().

### DIFF
--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -52,7 +52,7 @@ Adafruit_BNO055::Adafruit_BNO055(int32_t sensorID, uint8_t address)
     @brief  Sets up the HW
 */
 /**************************************************************************/
-bool Adafruit_BNO055::begin(adafruit_bno055_opmode_t mode)
+bool Adafruit_BNO055::begin(adafruit_bno055_opmode_t mode, uint8_t axis_remap_orientation, uint8_t axis_remap_sign)
 {
   /* Enable I2C */
   Wire.begin();
@@ -101,12 +101,10 @@ bool Adafruit_BNO055::begin(adafruit_bno055_opmode_t mode)
   */
 
   /* Configure axis mapping (see section 3.4) */
-  /*
-  write8(BNO055_AXIS_MAP_CONFIG_ADDR, REMAP_CONFIG_P2); // P0-P7, Default is P1
+  write8(BNO055_AXIS_MAP_CONFIG_ADDR, axis_remap_orientation); // P0-P7, Default is P1
   delay(10);
-  write8(BNO055_AXIS_MAP_SIGN_ADDR, REMAP_SIGN_P2); // P0-P7, Default is P1
+  write8(BNO055_AXIS_MAP_SIGN_ADDR, axis_remap_sign); // P0-P7, Default is P1
   delay(10);
-  */
   
   write8(BNO055_SYS_TRIGGER_ADDR, 0x0);
   delay(10);

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -236,30 +236,6 @@ class Adafruit_BNO055 : public Adafruit_Sensor
       OPERATION_MODE_NDOF                                     = 0X0C
     } adafruit_bno055_opmode_t;
 
-    typedef enum
-    {
-      REMAP_CONFIG_P0                                         = 0x21,
-      REMAP_CONFIG_P1                                         = 0x24, // default
-      REMAP_CONFIG_P2                                         = 0x24,
-      REMAP_CONFIG_P3                                         = 0x21,
-      REMAP_CONFIG_P4                                         = 0x24,
-      REMAP_CONFIG_P5                                         = 0x21,
-      REMAP_CONFIG_P6                                         = 0x21,
-      REMAP_CONFIG_P7                                         = 0x24
-    } adafruit_bno055_axis_remap_config_t;
-
-    typedef enum
-    {
-      REMAP_SIGN_P0                                           = 0x04,
-      REMAP_SIGN_P1                                           = 0x00, // default
-      REMAP_SIGN_P2                                           = 0x06,
-      REMAP_SIGN_P3                                           = 0x02,
-      REMAP_SIGN_P4                                           = 0x03,
-      REMAP_SIGN_P5                                           = 0x01,
-      REMAP_SIGN_P6                                           = 0x07,
-      REMAP_SIGN_P7                                           = 0x05
-    } adafruit_bno055_axis_remap_sign_t;
-
     typedef struct
     {
       uint8_t  accel_rev;
@@ -285,7 +261,9 @@ class Adafruit_BNO055 : public Adafruit_Sensor
 #else
     Adafruit_BNO055 ( int32_t sensorID = -1, uint8_t address = BNO055_ADDRESS_A );
 #endif
-    bool  begin               ( adafruit_bno055_opmode_t mode = OPERATION_MODE_NDOF );
+    bool  begin               ( adafruit_bno055_opmode_t mode = OPERATION_MODE_NDOF,
+                                uint8_t axis_remap_orientation = 0x24,
+                                uint8_t axis_remap_sign = 0x00);
     void  setMode             ( adafruit_bno055_opmode_t mode );
     void  getRevInfo          ( adafruit_bno055_rev_info_t* );
     void  displayRevInfo      ( void );


### PR DESCRIPTION
The axis remapping functionality of the BNO055 was already added by a previous contributor, though left commented out.  I re-enabled it and added additional parameters to begin() to pass in the required values.  Default values for these parameters ensure existing client code will still work as before.

I also removed the associated enums.  They were not used anywhere since the code was originally commented out, and simplified the remapping configurations to a degree that was restrictive.

No known limitations since it's all I2C.

Tested both default and remapped operation with a Feather M0.
