### PR TITLE
Add comment regarding order of operations for calibration restoration.

### DIFF
--- a/examples/restore_offsets/restore_offsets.ino
+++ b/examples/restore_offsets/restore_offsets.ino
@@ -204,6 +204,7 @@ void setup(void)
     /* Optional: Display current status */
     displaySensorStatus();
 
+   //Crystal must be configured AFTER loading calibration data into BNO055.
     bno.setExtCrystalUse(true);
 
     sensors_event_t event;


### PR DESCRIPTION
Per behavior I've discovered and tested today, the external crystal for the BNO055 must be configured only AFTER calibration data has loaded (setSensorOffsets). Failing to adhere to this order of operations prevents loaded calibration data from taking effect.

For example, if "bno.setExtCrystalUse(true);" is used right after "if(!bno.begin()){...}".

This change documents the required order of operations. I'd appreciate it if Adafruit would confirm. This information would have saved me an hour of debugging.
