### PR TITLE
Interrupt Functions

### DIFF
--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -595,8 +595,18 @@ bool Adafruit_BNO055::enableMotionInt( adafruit_bno055_intr_en_t int_en_code, in
 {
   // initialise flags
   int X_HG_EN = 0; int Y_HG_EN = 0; int Z_HG_EN = 0;
+  // set flags based on input String
   if (flags.indexOf("x") != '-1'){
-
+    X_HG_EN = 1;
+    Serial.println("X axis trigger enabled.");
+  }
+  if (flags.indexOf("y") != '-1'){
+    Y_HG_EN = 1;
+    Serial.println("Y axis trigger enabled.");
+  }
+  if (flags.indexOf("z") != '-1'){
+    Z_HG_EN = 1;
+    Serial.println("Z axis trigger enabled.");
   }
 
   adafruit_bno055_opmode_t lastMode = _mode;
@@ -644,7 +654,9 @@ bool Adafruit_BNO055::enableMotionInt( adafruit_bno055_intr_en_t int_en_code, in
   switch(int_en_code){
 
     case ACC_NM:
+      Serial.println("ACC_NM mode chosen.");
       write8(BNO055_INTR_ACCEL_NM_SETT, (0 << 0)); // this is setting whether or not slow or no motion is selected
+      write8(BNO055_INTR_ACCEL_NM_SETT, (1 << duration)); // this sets the number of points that must be above the threshold to trigger
       write8(BNO055_INTR_ACCEL_NM_THRES, (1 << threshold)); // this is dependent on ACC_CONFIG
     break;
 

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -636,15 +636,15 @@ bool Adafruit_BNO055::enableMotionInt( adafruit_bno055_intr_en_t int_en_code, in
 
 // TODO: Add flags to the function to allow deviation from default values!
 
+  if (int_en_code == ACC_AM){
+    write8(BNO055_INTR_ACCEL_NM_SETT, (1 << 0)); // this is setting whether or not slow or no motion is selected
+    write8(BNO055_INTR_ACCEL_NM_THRES, (1 << threshold)); // this is dependent on ACC_CONFIG
+  }
+
   switch(int_en_code){
 
     case ACC_NM:
       write8(BNO055_INTR_ACCEL_NM_SETT, (0 << 0)); // this is setting whether or not slow or no motion is selected
-      write8(BNO055_INTR_ACCEL_NM_THRES, (1 << threshold)); // this is dependent on ACC_CONFIG
-    break;
-
-    case ACC_SM:
-      write8(BNO055_INTR_ACCEL_NM_SETT, (1 << 0)); // this is setting whether or not slow or no motion is selected
       write8(BNO055_INTR_ACCEL_NM_THRES, (1 << threshold)); // this is dependent on ACC_CONFIG
     break;
 
@@ -657,14 +657,14 @@ bool Adafruit_BNO055::enableMotionInt( adafruit_bno055_intr_en_t int_en_code, in
       write8(BNO055_INTR_ACCEL_SETT, (int8_t)((X_HG_EN << 5) | (Y_HG_EN << 6) | (Z_HG_EN << 7)));
 
       // set duration of event required
-      if (duration < '256' && duration > '0'){
+      if ((duration < 256) && (duration > 0)){
         write8(BNO055_INTR_ACCEL_HG_DUR, duration); // literally write the value into the register
       } else {
         Serial.println("Duration value higher than 255!");
       }
 
       // set threshold of event required
-      if (threshold < '256' && threshold > '0'){
+      if ((threshold < 256) && (threshold > 0)){
         write8(BNO055_INTR_ACCEL_HG_THRES, threshold); // write the threshold value into the register
       } else {
         Serial.println("Threshold value higher than 255!");
@@ -679,12 +679,12 @@ bool Adafruit_BNO055::enableMotionInt( adafruit_bno055_intr_en_t int_en_code, in
       write8(BNO055_INTR_GYR_SETT, (int8_t)((0 << 7) | (1 << 5) | (1 << 4) | (1 << 3))); // selects filtered data for high-rate interrupt
     // set threshold, hysteresis and duration for each axis
     // TODO: specify values for durations!
-      write8(BNO055_INTR_GYR_HR_X_SET, int value);
-      write8(BNO055_INTR_GYR_DUR_X, int value);
-      write8(BNO055_INTR_GYR_HR_Y_SET, int value);
-      write8(BNO055_INTR_GYR_DUR_Y, int value);
-      write8(BNO055_INTR_GYR_HR_Z_SET, int value);
-      write8(BNO055_INTR_GYR_DUR_Z, int value);
+      write8(BNO055_INTR_GYR_HR_X_SET, (int8_t)(1 << 0)); // 0x19 is the default
+      write8(BNO055_INTR_GYR_DUR_X, 0x19);
+      write8(BNO055_INTR_GYR_HR_Y_SET, (int8_t)(1 << 0));
+      write8(BNO055_INTR_GYR_DUR_Y, 0x19);
+      write8(BNO055_INTR_GYR_HR_Z_SET, (int8_t)(1 << 0));
+      write8(BNO055_INTR_GYR_DUR_Z, 0x19);
     break;
     case GYRO_AM:
     // set GYR_INT_SET bit 7 and GYR_INT_SET 3:5

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -791,24 +791,82 @@ bool Adafruit_BNO055::enableInterruptAxes( adafruit_bno055_intr_en_t int_en_code
 @brief  Retrieve interrupt states and settings - DEBUG FUNCTION
 */
 /**************************************************************************/
-char * Adafruit_BNO055::checkInterruptStates()
+void Adafruit_BNO055::checkInterruptStates( )
 {
+  // enter config mode
+  adafruit_bno055_opmode_t modeback = _mode;
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
   // check the interrupt status register
-
-  // check the enable registers
-
+  uint8_t interrupt_status = readIntStatus();
+  // save selected page ID and switch to page 1
+  uint8_t savePageID = read8(BNO055_PAGE_ID_ADDR);
+  write8(BNO055_PAGE_ID_ADDR, 0x01);
+  // check all config registers
+  int8_t accel_config = read8(BNO055_ACCEL_CONFIG);
+  int8_t magneto_config = read8(BNO055_MAG_CONFIG);
+  int8_t gyro_config0 = read8(BNO055_GYRO_CONFIG0);
+  int8_t gyro_config1 = read8(BNO055_GYRO_CONFIG1);
+  // check the interrupt enable registers
+  int8_t interrupt_enables = read8(BNO055_INTR_EN_ADDR);
   // check the interrupt mask
-
-  // check the axis enable states
-
+  int8_t interrupt_mask = read8(BNO055_INTR_MSK_ADDR);
+  // check the accel axis enable states
+  int8_t accel_axis_enables = read8(BNO055_INTR_ACCEL_SETT);
+  // check the gyro axis enable states
+  int8_t gyro_axis_enables = read8(BNO055_INTR_GYR_SETT);
   // check the threshold levels
-
+  int8_t accel_nm_thresh = read8(BNO055_INTR_ACCEL_NM_THRES);
+  int8_t accel_am_thresh = read8(BNO055_INTR_ACCEL_AM_THRES);
+  int8_t accel_hg_thresh = read8(BNO055_INTR_ACCEL_HG_THRES);
+  int8_t gyro_am_thresh = read8(BNO055_INTR_GYR_AM_THRES);
   // check the duration levels
-
+  int8_t accel_nm_dur = read8(BNO055_INTR_ACCEL_NM_SETT);
+  int8_t accel_hg_dur = read8(BNO055_INTR_ACCEL_HG_DUR);
+  int8_t gyro_x_dur = read8(BNO055_INTR_GYR_DUR_X);
+  int8_t gyro_y_dur = read8(BNO055_INTR_GYR_DUR_Y);
+  int8_t gyro_z_dur = read8(BNO055_INTR_GYR_DUR_Z);
+  int8_t gyro_am_set = read8(BNO055_INTR_GYR_AM_SET);
   // check the hysteresis settings
-
-  // print settings as serial output
-
+  int8_t gyro_x_hyst = read8(BNO055_INTR_GYR_HR_X_SET);
+  int8_t gyro_y_hyst = read8(BNO055_INTR_GYR_HR_Y_SET);
+  int8_t gyro_z_hyst = read8(BNO055_INTR_GYR_HR_Z_SET);
+  // restore page ID
+  write8(BNO055_PAGE_ID_ADDR, savePageID);
+  // Set the previous operating mode (see section 3.3)
+  setMode(modeback);
+  delay(20);
+  // print current call on interrupt status (clears status register)
+  Serial.print("     INTERRUPT_STA: "); printWithZeros(interrupt_status, 'e');
+  // print all config registers
+  Serial.print("      ACCEL_CONFIG: "); printWithZeros(accel_config, 'e');
+  Serial.print("    MAGNETO_CONFIG: "); printWithZeros(magneto_config, 'e');
+  Serial.print("      GYRO_CONFIG0: "); printWithZeros(gyro_config0, 'e');
+  Serial.print("      GYRO_CONFIG1: "); printWithZeros(gyro_config1, 'e');
+  // print the interrupt enable registers
+  Serial.print(" INTERRUPT_ENABLES: "); printWithZeros(interrupt_enables, 'e');
+  // print the interrupt mask
+  Serial.print("    INTERRUPT_MASK: "); printWithZeros(interrupt_mask, 'e');
+  // print the accel axis enable states
+  Serial.print("ACCEL_AXIS_ENABLES: "); printWithZeros(accel_axis_enables, 'e');
+  // print the gyro axis enable states
+  Serial.print(" GYRO_AXIS_ENABLES: "); printWithZeros(gyro_axis_enables, 'e');
+  // print the threshold levels
+  Serial.print("   ACCEL_NM_THRESH: "); printWithZeros(accel_nm_thresh, 'e');
+  Serial.print("   ACCEL_AM_THRESH: "); printWithZeros(accel_am_thresh, 'e');
+  Serial.print("   ACCEL_HG_THRESH: "); printWithZeros(accel_hg_thresh, 'e');
+  Serial.print("    GYRO_AM_THRESH: "); printWithZeros(gyro_am_thresh, 'e');
+  // print the duration levels
+  Serial.print("      ACCEL_NM_DUR: "); printWithZeros(accel_nm_dur, 'e');
+  Serial.print("      ACCEL_HG_DUR: "); printWithZeros(accel_hg_dur, 'e');
+  Serial.print("        GYRO_X_DUR: "); printWithZeros(gyro_x_dur, 'e');
+  Serial.print("        GYRO_Y_DUR: "); printWithZeros(gyro_y_dur, 'e');
+  Serial.print("        GYRO_Z_DUR: "); printWithZeros(gyro_z_dur, 'e');
+  Serial.print("       GYRO_AM_SET: "); printWithZeros(gyro_am_set, 'e');
+  // print the hysteresis settings
+  Serial.print("       GYRO_X_HYST: "); printWithZeros(gyro_x_hyst, 'e');
+  Serial.print("       GYRO_Y_HYST: "); printWithZeros(gyro_y_hyst, 'e');
+  Serial.print("       GYRO_Z_HYST: "); printWithZeros(gyro_z_hyst, 'e');
 }
 
 /**************************************************************************/
@@ -818,11 +876,15 @@ char * Adafruit_BNO055::checkInterruptStates()
 /**************************************************************************/
 int8_t Adafruit_BNO055::readIntStatus()
 {
-  setMode(OPERATION_MODE_CONFIG); // change to config to change page
+  // enter config mode
+  adafruit_bno055_opmode_t modeback = _mode;
+  setMode(OPERATION_MODE_CONFIG);
   delay(25);
 
-  write8(BNO055_PAGE_ID_ADDR, 0); // set access to the first register page
-  delay(25);
+  // save selected page ID and switch to page 0
+  uint8_t savePageID = read8(BNO055_PAGE_ID_ADDR);
+  write8(BNO055_PAGE_ID_ADDR, 0x00);
+
   // read from INT_STA to determine the type of interrupt occurance
   int8_t intstatus = read8(BNO055_INTR_STAT_ADDR);
 
@@ -833,6 +895,13 @@ int8_t Adafruit_BNO055::readIntStatus()
      8 = Gyroscope high-rate interrupt
      32 = Accelerometer any-motion interrupt
      49 = Accelerometer no-motion/slow-motion interrupt */
+
+   // restore page ID
+   write8(BNO055_PAGE_ID_ADDR, savePageID);
+
+   // Set the requested operating mode (see section 3.3)
+   setMode(modeback);
+   delay(20);
 
   return intstatus;
 }
@@ -914,4 +983,24 @@ bool Adafruit_BNO055::readLen(adafruit_bno055_reg_t reg, byte * buffer, uint8_t 
 
   /* ToDo: Check for errors! */
   return true;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Prints 8-bit register value with leading zeros
+*/
+/**************************************************************************/
+void Adafruit_BNO055::printWithZeros ( uint8_t input, char flag )
+{
+  for (uint8_t mask = 0x80; mask; mask >>= 1) {
+      if (mask & input) {
+          Serial.print('1');
+      }
+      else {
+          Serial.print('0');
+      }
+  }
+  if (flag == 'e'){
+    Serial.print('\n');
+  }
 }

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -591,11 +591,11 @@ bool Adafruit_BNO055::isFullyCalibrated(void)
 @brief  Enables interrupt and links it to the INT pin
 */
 /**************************************************************************/
-bool Adafruit_BNO055::enableMotionInt( adafruit_bno055_intr_en_t int_en_code, int8_t duration, int8_t threshold, std::string flags )
+bool Adafruit_BNO055::enableMotionInt( adafruit_bno055_intr_en_t int_en_code, int8_t duration, int8_t threshold, char flags[3] )
 {
   // initialise flags
   int X_HG_EN = 0; int Y_HG_EN = 0; int Z_HG_EN = 0;
-  if (!flags.compare("x")){
+  if (flags.indexOf("x") != '-1'){
 
   }
 

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -591,7 +591,7 @@ bool Adafruit_BNO055::isFullyCalibrated(void)
 @brief  Enables interrupt and links it to the INT pin
 */
 /**************************************************************************/
-bool Adafruit_BNO055::enableMotionInt( adafruit_bno055_intr_en_t int_en_code, int8_t duration, int8_t threshold, char flags[3] )
+bool Adafruit_BNO055::enableMotionInt( adafruit_bno055_intr_en_t int_en_code, int8_t duration, int8_t threshold, String flags )
 {
   // initialise flags
   int X_HG_EN = 0; int Y_HG_EN = 0; int Z_HG_EN = 0;

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -107,7 +107,7 @@ bool Adafruit_BNO055::begin(adafruit_bno055_opmode_t mode)
   write8(BNO055_AXIS_MAP_SIGN_ADDR, REMAP_SIGN_P2); // P0-P7, Default is P1
   delay(10);
   */
-  
+
   write8(BNO055_SYS_TRIGGER_ADDR, 0x0);
   delay(10);
   /* Set the requested operating mode (see section 3.3) */
@@ -128,6 +128,43 @@ void Adafruit_BNO055::setMode(adafruit_bno055_opmode_t mode)
   write8(BNO055_OPR_MODE_ADDR, _mode);
   delay(30);
 }
+
+/**************************************************************************/
+/*!
+    @brief  Changes the chip's axis remap
+*/
+/**************************************************************************/
+void Adafruit_BNO055::setAxisRemap( adafruit_bno055_axis_remap_config_t remapcode )
+{
+  adafruit_bno055_opmode_t modeback = _mode;
+
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
+  write8(BNO055_AXIS_MAP_CONFIG_ADDR, remapcode);
+  delay(10);
+  /* Set the requested operating mode (see section 3.3) */
+  setMode(modeback);
+  delay(20);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Changes the chip's axis signs
+*/
+/**************************************************************************/
+void Adafruit_BNO055::setAxisSign( adafruit_bno055_axis_remap_sign_t remapsign )
+{
+  adafruit_bno055_opmode_t modeback = _mode;
+
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
+  write8(BNO055_AXIS_MAP_SIGN_ADDR, remapsign);
+  delay(10);
+  /* Set the requested operating mode (see section 3.3) */
+  setMode(modeback);
+  delay(20);
+}
+
 
 /**************************************************************************/
 /*!

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -35,7 +35,7 @@
 
 #include <Adafruit_Sensor.h>
 #include <utility/imumaths.h>
-#include <string>
+#include <string.h>
 
 #define BNO055_ADDRESS_A (0x28)
 #define BNO055_ADDRESS_B (0x29)

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -320,7 +320,7 @@ class Adafruit_BNO055 : public Adafruit_Sensor
     void  setMode             ( adafruit_bno055_opmode_t mode );
     void  setAxisRemap        ( adafruit_bno055_axis_remap_config_t remapcode );
     void  setAxisSign         ( adafruit_bno055_axis_remap_sign_t remapsign );
-    bool  enableMotionInt     ( adafruit_bno055_intr_en_t int_en_code, int8_t duration, int8_t threshold, char flags[3] );
+    bool  enableMotionInt     ( adafruit_bno055_intr_en_t int_en_code, int8_t duration, int8_t threshold, String flags );
     void  getRevInfo          ( adafruit_bno055_rev_info_t* );
     void  displayRevInfo      ( void );
     void  setExtCrystalUse    ( boolean usextal );

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -1,4 +1,4 @@
-z/***************************************************************************
+/***************************************************************************
   This is a library for the BNO055 orientation sensor
 
   Designed specifically to work with the Adafruit BNO055 Breakout.
@@ -19,6 +19,9 @@ z/***************************************************************************
 
 #ifndef __ADAFRUIT_BNO055_H__
 #define __ADAFRUIT_BNO055_H__
+
+#include <iostream>
+#include <string>
 
 #if (ARDUINO >= 100)
  #include "Arduino.h"
@@ -139,6 +142,8 @@ class Adafruit_BNO055 : public Adafruit_Sensor
       /* Status registers */
       BNO055_CALIB_STAT_ADDR                                  = 0X35,
       BNO055_SELFTEST_RESULT_ADDR                             = 0X36,
+
+      /* Interrupt status register PAGE 0 */
       BNO055_INTR_STAT_ADDR                                   = 0X37,
 
       BNO055_SYS_CLK_STAT_ADDR                                = 0X38,
@@ -155,6 +160,25 @@ class Adafruit_BNO055 : public Adafruit_Sensor
 
       BNO055_SYS_TRIGGER_ADDR                                 = 0X3F,
       BNO055_TEMP_SOURCE_ADDR                                 = 0X40,
+
+      /* Interrupt config registers PAGE 1 */
+      BNO055_INTR_EN_ADDR                                     = 0x10,
+      BNO055_INTR_MSK_ADDR                                    = 0x0F,
+      BNO055_INTR_ACCEL_AM_THRES                              = 0x11,
+      BNO055_INTR_ACCEL_SETT                                  = 0x12,
+      BNO055_INTR_ACCEL_HG_DUR                                = 0x13,
+      BNO055_INTR_ACCEL_HG_THRES                              = 0x14,
+      BNO055_INTR_ACCEL_NM_THRES                              = 0x15,
+      BNO055_INTR_ACCEL_NM_SETT                               = 0x16,
+      BNO055_INTR_GYR_SETT                                    = 0x17,
+      BNO055_INTR_GYR_HR_X_SET                                = 0x18,
+      BNO055_INTR_GYR_DUR_X                                   = 0x19,
+      BNO055_INTR_GYR_HR_Y_SET                                = 0x1A,
+      BNO055_INTR_GYR_DUR_Y                                   = 0x1B,
+      BNO055_INTR_GYR_HR_Z_SET                                = 0x1C,
+      BNO055_INTR_GYR_DUR_Z                                   = 0x1D,
+      BNO055_INTR_GYR_AM_THRES                                = 0x1E,
+      BNO055_INTR_GYR_AM_SET                                  = 0x1F,
 
       /* Axis remap registers */
       BNO055_AXIS_MAP_CONFIG_ADDR                             = 0X41,
@@ -260,6 +284,16 @@ class Adafruit_BNO055 : public Adafruit_Sensor
       REMAP_SIGN_P7                                           = 0x05
     } adafruit_bno055_axis_remap_sign_t;
 
+    typedef enum
+    {
+      ACC_NM                                                  = 7,
+      ACC_SM                                                  = 7,
+      ACC_AM                                                  = 6, // default
+      ACC_HIGH_G                                              = 5,
+      GYR_HIGH_RATE                                           = 3,
+      GYRO_AM                                                 = 2
+    } adafruit_bno055_intr_en_t;
+
     typedef struct
     {
       uint8_t  accel_rev;
@@ -289,6 +323,7 @@ class Adafruit_BNO055 : public Adafruit_Sensor
     void  setMode             ( adafruit_bno055_opmode_t mode );
     void  setAxisRemap        ( adafruit_bno055_axis_remap_config_t remapcode );
     void  setAxisSign         ( adafruit_bno055_axis_remap_sign_t remapsign );
+    bool  enableMotionInt     ( adafruit_bno055_intr_en_t int_en_code, int8_t duration, int8_t threshold, std::string flags );
     void  getRevInfo          ( adafruit_bno055_rev_info_t* );
     void  displayRevInfo      ( void );
     void  setExtCrystalUse    ( boolean usextal );
@@ -301,6 +336,7 @@ class Adafruit_BNO055 : public Adafruit_Sensor
     imu::Vector<3>  getVector ( adafruit_vector_type_t vector_type );
     imu::Quaternion getQuat   ( void );
     int8_t          getTemp   ( void );
+    int8_t readIntStatus     ( void );
 
     /* Adafruit_Sensor implementation */
     bool  getEvent  ( sensors_event_t* );
@@ -316,7 +352,7 @@ class Adafruit_BNO055 : public Adafruit_Sensor
   private:
     byte  read8   ( adafruit_bno055_reg_t );
     bool  readLen ( adafruit_bno055_reg_t, byte* buffer, uint8_t len );
-    bool  write8  ( adafruit_bno055_reg_t, byte value );
+    int8_t  write8  ( adafruit_bno055_reg_t, byte value );
 
     uint8_t _address;
     int32_t _sensorID;

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -35,7 +35,7 @@
 
 #include <Adafruit_Sensor.h>
 #include <utility/imumaths.h>
-#include <string.h>
+#include <string>
 
 #define BNO055_ADDRESS_A (0x28)
 #define BNO055_ADDRESS_B (0x29)

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -35,6 +35,7 @@
 
 #include <Adafruit_Sensor.h>
 #include <utility/imumaths.h>
+#include <string>
 
 #define BNO055_ADDRESS_A (0x28)
 #define BNO055_ADDRESS_B (0x29)

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -328,6 +328,7 @@ class Adafruit_BNO055 : public Adafruit_Sensor
     void  setAxisSign         ( adafruit_bno055_axis_remap_sign_t remapsign );
     bool  enableInterrupts    ( adafruit_bno055_intr_en_t int_en_code, bool triggerPin);
     bool  enableInterruptAxes ( adafruit_bno055_intr_en_t int_en_code, String axes );
+    bool  setIntThreshold     ( adafruit_bno055_intr_en_t int_en_code, int duration );
     void  getRevInfo          ( adafruit_bno055_rev_info_t* );
     void  displayRevInfo      ( void );
     void  setExtCrystalUse    ( boolean usextal );

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -177,6 +177,12 @@ class Adafruit_BNO055 : public Adafruit_Sensor
       BNO055_INTR_GYR_AM_THRES                                = 0x1E,
       BNO055_INTR_GYR_AM_SET                                  = 0x1F,
 
+      /* Sensor config registers */
+      BNO055_ACCEL_CONFIG                                     = 0x08,
+      BNO055_MAG_CONFIG                                       = 0x09,
+      BNO055_GYRO_CONFIG0                                     = 0x0A,
+      BNO055_GYRO_CONFIG1                                     = 0x0B,
+
       /* Axis remap registers */
       BNO055_AXIS_MAP_CONFIG_ADDR                             = 0X41,
       BNO055_AXIS_MAP_SIGN_ADDR                               = 0X42,
@@ -325,7 +331,7 @@ class Adafruit_BNO055 : public Adafruit_Sensor
     void  getRevInfo          ( adafruit_bno055_rev_info_t* );
     void  displayRevInfo      ( void );
     void  setExtCrystalUse    ( boolean usextal );
-    char * checkInterruptStates( void );
+    void  checkInterruptStates( void );
     void  getSystemStatus     ( uint8_t *system_status,
                                 uint8_t *self_test_result,
                                 uint8_t *system_error);
@@ -335,7 +341,7 @@ class Adafruit_BNO055 : public Adafruit_Sensor
     imu::Vector<3>  getVector ( adafruit_vector_type_t vector_type );
     imu::Quaternion getQuat   ( void );
     int8_t          getTemp   ( void );
-    int8_t readIntStatus     ( void );
+    int8_t readIntStatus      ( void );
 
     /* Adafruit_Sensor implementation */
     bool  getEvent  ( sensors_event_t* );
@@ -352,6 +358,7 @@ class Adafruit_BNO055 : public Adafruit_Sensor
     byte  read8   ( adafruit_bno055_reg_t );
     bool  readLen ( adafruit_bno055_reg_t, byte* buffer, uint8_t len );
     int8_t  write8  ( adafruit_bno055_reg_t, byte value );
+    void  printWithZeros ( uint8_t input, char flag );
 
     uint8_t _address;
     int32_t _sensorID;

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -1,4 +1,4 @@
-/***************************************************************************
+z/***************************************************************************
   This is a library for the BNO055 orientation sensor
 
   Designed specifically to work with the Adafruit BNO055 Breakout.
@@ -287,6 +287,8 @@ class Adafruit_BNO055 : public Adafruit_Sensor
 #endif
     bool  begin               ( adafruit_bno055_opmode_t mode = OPERATION_MODE_NDOF );
     void  setMode             ( adafruit_bno055_opmode_t mode );
+    void  setAxisRemap        ( adafruit_bno055_axis_remap_config_t remapcode );
+    void  setAxisSign         ( adafruit_bno055_axis_remap_sign_t remapsign );
     void  getRevInfo          ( adafruit_bno055_rev_info_t* );
     void  displayRevInfo      ( void );
     void  setExtCrystalUse    ( boolean usextal );

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -35,7 +35,6 @@
 
 #include <Adafruit_Sensor.h>
 #include <utility/imumaths.h>
-#include <string>
 
 #define BNO055_ADDRESS_A (0x28)
 #define BNO055_ADDRESS_B (0x29)
@@ -321,7 +320,7 @@ class Adafruit_BNO055 : public Adafruit_Sensor
     void  setMode             ( adafruit_bno055_opmode_t mode );
     void  setAxisRemap        ( adafruit_bno055_axis_remap_config_t remapcode );
     void  setAxisSign         ( adafruit_bno055_axis_remap_sign_t remapsign );
-    bool  enableMotionInt     ( adafruit_bno055_intr_en_t int_en_code, int8_t duration, int8_t threshold, std::string flags );
+    bool  enableMotionInt     ( adafruit_bno055_intr_en_t int_en_code, int8_t duration, int8_t threshold, char flags[3] );
     void  getRevInfo          ( adafruit_bno055_rev_info_t* );
     void  displayRevInfo      ( void );
     void  setExtCrystalUse    ( boolean usextal );

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -284,7 +284,7 @@ class Adafruit_BNO055 : public Adafruit_Sensor
     typedef enum
     {
       ACC_NM                                                  = 7,
-      ACC_SM                                                  = 0x7,
+      ACC_SM                                                  = 8,
       ACC_AM                                                  = 6, // default
       ACC_HIGH_G                                              = 5,
       GYR_HIGH_RATE                                           = 3,
@@ -320,10 +320,12 @@ class Adafruit_BNO055 : public Adafruit_Sensor
     void  setMode             ( adafruit_bno055_opmode_t mode );
     void  setAxisRemap        ( adafruit_bno055_axis_remap_config_t remapcode );
     void  setAxisSign         ( adafruit_bno055_axis_remap_sign_t remapsign );
-    bool  enableMotionInt     ( adafruit_bno055_intr_en_t int_en_code, int8_t duration, int8_t threshold, String flags );
+    bool  enableInterrupts    ( adafruit_bno055_intr_en_t int_en_code, bool triggerPin);
+    bool  enableInterruptAxes ( adafruit_bno055_intr_en_t int_en_code, String axes );
     void  getRevInfo          ( adafruit_bno055_rev_info_t* );
     void  displayRevInfo      ( void );
     void  setExtCrystalUse    ( boolean usextal );
+    char * checkInterruptStates( void );
     void  getSystemStatus     ( uint8_t *system_status,
                                 uint8_t *self_test_result,
                                 uint8_t *system_error);

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -20,8 +20,6 @@
 #ifndef __ADAFRUIT_BNO055_H__
 #define __ADAFRUIT_BNO055_H__
 
-#include <iostream>
-
 #if (ARDUINO >= 100)
  #include "Arduino.h"
 #else

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -21,7 +21,6 @@
 #define __ADAFRUIT_BNO055_H__
 
 #include <iostream>
-#include <string>
 
 #if (ARDUINO >= 100)
  #include "Arduino.h"
@@ -287,7 +286,7 @@ class Adafruit_BNO055 : public Adafruit_Sensor
     typedef enum
     {
       ACC_NM                                                  = 7,
-      ACC_SM                                                  = 7,
+      ACC_SM                                                  = 0x7,
       ACC_AM                                                  = 6, // default
       ACC_HIGH_G                                              = 5,
       GYR_HIGH_RATE                                           = 3,


### PR DESCRIPTION
Interrupt Codes:
ACC_NM - Accelerometer No Motion
ACC_SM - Accelerometer Slow Motion
ACC_AM - Accelerometer Any Motion
ACC_HIGH_G - Accelerometer High G
GYR_HIGH_RATE - Gyroscope High Rate
GYRO_AM - Gyroscope Any Motion

**enableInterrupts()** takes the type of interrupt code, such as ACC_NM (Accelerometer No Motion), and whether the developer wants the INT pin to trigger as two arguments.

**enableInterruptAxes()** takes the interrupt code, and the axes to allow to trigger it, as two arguments and enables them. Currently there is no 'disable' function but this is due.

**setIntThreshold()** takes the interrupt code and a threshold value, as well as a string to define the axis and sets the input to exceed in order to trigger an interrupt. Each type of threshold is different for each code, so there is a serial output comment to reflect when the developer has set an invalid value. This can be made unnecessary by adding the function usage case to the Wiki.

**setIntDuration()** take the interrupt code and a duration value, as as a string to define the axes (not implemented currently), and sets the duration for which the threshold must be exceeded in order to trigger.

**checkInterruptStates()** is a sanity check for all interrupt registers, allowing the developer to drop this into their code and check setup and runtime behaviours.

**readIntStatus()** is best used as the callback function for the interrupt service routine, reading the status code from the INT_STA register.

**clearInt()** clears and resets the interrupt so the pin will return to it's previous level.

**printWithZeros()** ensures the register values are printed with their leading zeros.