### PR TITLE
trim list[4] so that it parses as an int correctly

### DIFF
--- a/examples/bunny/processing/cuberotate/cuberotate.pde
+++ b/examples/bunny/processing/cuberotate/cuberotate.pde
@@ -135,7 +135,7 @@ void serialEvent(Serial p)
       int sysCal   = int(list[1]);
       int gyroCal  = int(list[2]);
       int accelCal = int(list[3]);
-      int magCal   = int(list[4]);
+      int magCal   = int(trim(list[4]));
       calLabel.setText("Calibration: Sys=" + sysCal + " Gyro=" + gyroCal + " Accel=" + accelCal + " Mag=" + magCal);
     }
   }


### PR DESCRIPTION
Add trim to list[4] when parsing it as an int and assigning it to magCal variable. This always parses as a 0 if the new line is not trimmed from list[4]. Now correct calibration data for the magnetometer will show in the gui. This makes the example work properly.
