### PR TITLE
isFullyCalibrated() needs to depend on the sensor mode

### DIFF
--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -612,9 +612,27 @@ bool Adafruit_BNO055::isFullyCalibrated(void)
 {
     uint8_t system, gyro, accel, mag;
     getCalibration(&system, &gyro, &accel, &mag);
-    if (system < 3 || gyro < 3 || accel < 3 || mag < 3)
-        return false;
-    return true;
+    
+    switch(_mode)
+    {
+      case OPERATION_MODE_ACCONLY:
+        return (accel==3);
+      case OPERATION_MODE_MAGONLY:
+        return (mag==3);
+      case OPERATION_MODE_GYRONLY:
+      case OPERATION_MODE_M4G: /* No magnetometer calibration required. */
+        return (gyro==3);
+      case OPERATION_MODE_ACCMAG:
+      case OPERATION_MODE_COMPASS:
+        return (accel==3 && mag==3);
+      case OPERATION_MODE_ACCGYRO:
+      case OPERATION_MODE_IMUPLUS:
+        return (accel==3 && gyro==3);
+      case OPERATION_MODE_MAGGYRO:
+        return (mag==3 && gyro==3);
+      default:
+        return (system==3 && gyro==3 && accel==3 && mag==3);
+    }
 }
 
 


### PR DESCRIPTION
Depending on the mode, full calibration can be achieved, before all sensor types are calibrated. E.g. `OPERATION_MODE_IMUPLUS` requires only the gyro and the accelerometer. The magnetometer calibration status and the system overall calibration status are always `0` in this mode, according to my observations.

Before the PR, the user could only obtain sensor offsets, when the calibration status for all sensors were `3`. This condition cannot be met in most operation modes and is also not required. As a result, the method for getting the calibration offsets returned uninitialized data in such modes.

Known limitations: None

Testing and backcompatibility: This PR should not brake any existing code, as the behavior of the method for the default operation mode is unaltered. I have tested it for `OPERATION_MODE_NDOF` (no changes in behavior) and `OPERATION_MODE_IMUPLUS` (PR enables correct detection of fullyCalibrated state and successful reading of calibration offsets).
