### PR TITLE
 Corrected a typo that caused getEvent to return the incorrect type when using linear acceleration data. 

### DIFF
--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -529,7 +529,7 @@ bool Adafruit_BNO055::getEvent(sensors_event_t *event, adafruit_vector_type_t ve
   imu::Vector<3> vec;
   if (vec_type == Adafruit_BNO055::VECTOR_LINEARACCEL)
   {
-    event->type = SENSOR_TYPE_ACCELEROMETER;
+    event->type = SENSOR_TYPE_LINEAR_ACCELERATION;
     vec = getVector(Adafruit_BNO055::VECTOR_LINEARACCEL);
 
     event->acceleration.x = vec.x();


### PR DESCRIPTION
This pull request fixes #67. To correct a typo that caused getEvent to return the incorrect type when using linear acceleration data. I modified Adafruit_BNO055.cpp and changed a single line to have the linear acceleration data type set to  `event->type = SENSOR_TYPE_LINEAR_ACCELERATION`.

This change should be supported on all platforms and should not introduce any limitations.

I tested the code by running the change on an UNO/R3 and verifying the `SENSOR_TYPE_LINEAR_ACCELERATION` is returned as the event type when `getEvent` is called.