### PR TITLE
Added default I2C address

### DIFF
--- a/examples/bunny/bunny.ino
+++ b/examples/bunny/bunny.ino
@@ -32,7 +32,7 @@
 
 // Check I2C device address and correct line below (by default address is 0x29 or 0x28)
 //                                   id, address
-Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x29);
+Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x28);
 
 /**************************************************************************/
 /*

--- a/examples/bunny/bunny.ino
+++ b/examples/bunny/bunny.ino
@@ -30,7 +30,9 @@
 /* Set the delay between fresh samples */
 #define BNO055_SAMPLERATE_DELAY_MS (100)
 
-Adafruit_BNO055 bno = Adafruit_BNO055(55);
+// Check I2C device address and correct line below (by default address is 0x29 or 0x28)
+//                                   id, address
+Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x29);
 
 /**************************************************************************/
 /*

--- a/examples/position/position.ino
+++ b/examples/position/position.ino
@@ -15,7 +15,7 @@ double DEG_2_RAD = 0.01745329251; //trig functions require radians, BNO055 outpu
 
 // Check I2C device address and correct line below (by default address is 0x29 or 0x28)
 //                                   id, address
-Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x29);
+Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x28);
 
 void setup(void)
 {

--- a/examples/position/position.ino
+++ b/examples/position/position.ino
@@ -13,7 +13,9 @@ double ACCEL_VEL_TRANSITION =  (double)(BNO055_SAMPLERATE_DELAY_MS) / 1000.0;
 double ACCEL_POS_TRANSITION = 0.5 * ACCEL_VEL_TRANSITION * ACCEL_VEL_TRANSITION;
 double DEG_2_RAD = 0.01745329251; //trig functions require radians, BNO055 outputs degrees
 
-Adafruit_BNO055 bno = Adafruit_BNO055(55);
+// Check I2C device address and correct line below (by default address is 0x29 or 0x28)
+//                                   id, address
+Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x29);
 
 void setup(void)
 {

--- a/examples/rawdata/rawdata.ino
+++ b/examples/rawdata/rawdata.ino
@@ -20,7 +20,9 @@
 /* Set the delay between fresh samples */
 #define BNO055_SAMPLERATE_DELAY_MS (100)
 
-Adafruit_BNO055 bno = Adafruit_BNO055();
+// Check I2C device address and correct line below (by default address is 0x29 or 0x28)
+//                                   id, address
+Adafruit_BNO055 bno = Adafruit_BNO055(-1, 0x29);
 
 /**************************************************************************/
 /*
@@ -29,7 +31,7 @@ Adafruit_BNO055 bno = Adafruit_BNO055();
 /**************************************************************************/
 void setup(void)
 {
-  Serial.begin(9600);
+  Serial.begin(115200);
   Serial.println("Orientation Sensor Raw Data Test"); Serial.println("");
 
   /* Initialise the sensor */

--- a/examples/rawdata/rawdata.ino
+++ b/examples/rawdata/rawdata.ino
@@ -22,7 +22,7 @@
 
 // Check I2C device address and correct line below (by default address is 0x29 or 0x28)
 //                                   id, address
-Adafruit_BNO055 bno = Adafruit_BNO055(-1, 0x29);
+Adafruit_BNO055 bno = Adafruit_BNO055(-1, 0x28);
 
 /**************************************************************************/
 /*

--- a/examples/read_all_data/read_all_data.ino
+++ b/examples/read_all_data/read_all_data.ino
@@ -32,7 +32,7 @@ uint16_t BNO055_SAMPLERATE_DELAY_MS = 100;
 
 // Check I2C device address and correct line below (by default address is 0x29 or 0x28)
 //                                   id, address
-Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x29);
+Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x28);
 
 void setup(void)
 {

--- a/examples/read_all_data/read_all_data.ino
+++ b/examples/read_all_data/read_all_data.ino
@@ -30,7 +30,9 @@
 /* Set the delay between fresh samples */
 uint16_t BNO055_SAMPLERATE_DELAY_MS = 100;
 
-Adafruit_BNO055 bno = Adafruit_BNO055(55);
+// Check I2C device address and correct line below (by default address is 0x29 or 0x28)
+//                                   id, address
+Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x29);
 
 void setup(void)
 {

--- a/examples/restore_offsets/restore_offsets.ino
+++ b/examples/restore_offsets/restore_offsets.ino
@@ -33,7 +33,9 @@
 /* Set the delay between fresh samples */
 #define BNO055_SAMPLERATE_DELAY_MS (100)
 
-Adafruit_BNO055 bno = Adafruit_BNO055(55);
+// Check I2C device address and correct line below (by default address is 0x29 or 0x28)
+//                                   id, address
+Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x29);
 
 /**************************************************************************/
 /*

--- a/examples/restore_offsets/restore_offsets.ino
+++ b/examples/restore_offsets/restore_offsets.ino
@@ -35,7 +35,7 @@
 
 // Check I2C device address and correct line below (by default address is 0x29 or 0x28)
 //                                   id, address
-Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x29);
+Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x28);
 
 /**************************************************************************/
 /*

--- a/examples/sensorapi/sensorapi.ino
+++ b/examples/sensorapi/sensorapi.ino
@@ -31,7 +31,9 @@
 /* Set the delay between fresh samples */
 #define BNO055_SAMPLERATE_DELAY_MS (100)
 
-Adafruit_BNO055 bno = Adafruit_BNO055(55);
+// Check I2C device address and correct line below (by default address is 0x29 or 0x28)
+//                                   id, address
+Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x29);
 
 /**************************************************************************/
 /*
@@ -118,7 +120,7 @@ void displayCalStatus(void)
 /**************************************************************************/
 void setup(void)
 {
-  Serial.begin(9600);
+  Serial.begin(115200);
   Serial.println("Orientation Sensor Test"); Serial.println("");
 
   /* Initialise the sensor */

--- a/examples/sensorapi/sensorapi.ino
+++ b/examples/sensorapi/sensorapi.ino
@@ -33,7 +33,7 @@
 
 // Check I2C device address and correct line below (by default address is 0x29 or 0x28)
 //                                   id, address
-Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x29);
+Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x28);
 
 /**************************************************************************/
 /*


### PR DESCRIPTION
It took a long time to understand that I need to pass address to Adafruit_BNO055().
By adding default address (0x29) it should work on first run and save someone a headache. 
Also changed Serial baud rate to 115200 for continuity between examples.
