### PR TITLE
Print linear acceleration events

### DIFF
--- a/examples/read_all_data/read_all_data.ino
+++ b/examples/read_all_data/read_all_data.ino
@@ -74,7 +74,7 @@ void printEvent(sensors_event_t* event) {
   Serial.println();
   Serial.print(event->type);
   double x = -1000000, y = -1000000 , z = -1000000; //dumb values, easy to spot problem
-  if (event->type == SENSOR_TYPE_ACCELEROMETER) {
+  if ((event->type == SENSOR_TYPE_ACCELEROMETER) || (event->type == SENSOR_TYPE_LINEAR_ACCELERATION)) {
     x = event->acceleration.x;
     y = event->acceleration.y;
     z = event->acceleration.z;


### PR DESCRIPTION
Updates the read_all_data example to be able to print linear acceleration values.

Previously printEvent(&linearAccelData) printed dummy values of -1000000 for each axis. With this change, values are printed correctly, e.g. "10: x= -0.09 | y= 0.07 | z= -0.11"