### PR TITLE
When reading on i2c, endTransmission() should not release the bus sin…

### DIFF
--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -859,7 +859,7 @@ byte Adafruit_BNO055::read8(adafruit_bno055_reg_t reg) {
 #else
   _wire->send(reg);
 #endif
-  _wire->endTransmission();
+  _wire->endTransmission(false);
   _wire->requestFrom(_address, (byte)1);
 #if ARDUINO >= 100
   value = _wire->read();
@@ -881,7 +881,7 @@ bool Adafruit_BNO055::readLen(adafruit_bno055_reg_t reg, byte *buffer,
 #else
   _wire->send(reg);
 #endif
-  _wire->endTransmission();
+  _wire->endTransmission(false);
   _wire->requestFrom(_address, (byte)len);
 
   for (uint8_t i = 0; i < len; i++) {


### PR DESCRIPTION
When reading on i2c, endTransmission() should not release the bus since requestFrom() is called right after.

Therefore endTransmission() should be called with false, in both Adafruit_BNO055::read8() and Adafruit_BNO055::readLen().