### PR TITLE
imumaths.h is local to Adafruit_BNO055 project, it needs to be include with "" and not <>

### DIFF
--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -26,7 +26,7 @@
 #include <Wire.h>
 
 #include <Adafruit_Sensor.h>
-#include <utility/imumaths.h>
+#include "utility/imumaths.h"
 
 /** BNO055 Address A **/
 #define BNO055_ADDRESS_A (0x28)


### PR DESCRIPTION
imumaths.h is local to Adafruit_BNO055 project, it needs to be include with "" and not <>.

This is to avoid errors with some compilers.