### PR TITLE
Removing BNO055_DATA_SELECT_ADDR, this address doesn't exist in BNO055 datasheet

### DIFF
--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -149,7 +149,6 @@ public:
 
     /* Unit selection register */
     BNO055_UNIT_SEL_ADDR = 0X3B,
-    BNO055_DATA_SELECT_ADDR = 0X3C,
 
     /* Mode registers */
     BNO055_OPR_MODE_ADDR = 0X3D,


### PR DESCRIPTION
Removing BNO055_DATA_SELECT_ADDR, this address doesn't exist in BNO055 datasheet.

According to https://cdn-shop.adafruit.com/datasheets/BST_BNO055_DS000_12.pdf 0X3C is a reserved value.

