### PR TITLE
Nicer output form read_all_data example

### DIFF
--- a/examples/read_all_data/read_all_data.ino
+++ b/examples/read_all_data/read_all_data.ino
@@ -63,43 +63,53 @@ void loop(void)
   printEvent(&linearAccelData);
 
   int8_t boardTemp = bno.getTemp();
+  Serial.println();
   Serial.print(F("temperature: "));
   Serial.println(boardTemp);
 
-
+  Serial.println("--");
   delay(BNO055_SAMPLERATE_DELAY_MS);
 }
 
 void printEvent(sensors_event_t* event) {
-  Serial.println();
-  Serial.print(event->type);
   double x = -1000000, y = -1000000 , z = -1000000; //dumb values, easy to spot problem
   if (event->type == SENSOR_TYPE_ACCELEROMETER) {
+    Serial.print("Accl:");
     x = event->acceleration.x;
     y = event->acceleration.y;
     z = event->acceleration.z;
   }
   else if (event->type == SENSOR_TYPE_ORIENTATION) {
+    Serial.print("Orient:");
     x = event->orientation.x;
     y = event->orientation.y;
     z = event->orientation.z;
   }
   else if (event->type == SENSOR_TYPE_MAGNETIC_FIELD) {
+    Serial.print("Mag:");
     x = event->magnetic.x;
     y = event->magnetic.y;
     z = event->magnetic.z;
   }
-  else if ((event->type == SENSOR_TYPE_GYROSCOPE) || (event->type == SENSOR_TYPE_ROTATION_VECTOR)) {
+  else if (event->type == SENSOR_TYPE_GYROSCOPE) {
+    Serial.print("Gyro:");
     x = event->gyro.x;
     y = event->gyro.y;
     z = event->gyro.z;
+  } else if (event->type == SENSOR_TYPE_ROTATION_VECTOR) {
+    Serial.print("Rot:");
+    x = event->gyro.x;
+    y = event->gyro.y;
+    z = event->gyro.z;
+  } else {
+    Serial.print("Unk:");
   }
 
-  Serial.print(": x= ");
+  Serial.print("\tx= ");
   Serial.print(x);
-  Serial.print(" | y= ");
+  Serial.print(" |\ty= ");
   Serial.print(y);
-  Serial.print(" | z= ");
+  Serial.print(" |\tz= ");
   Serial.println(z);
 }
 


### PR DESCRIPTION
Changing the output of read_all_data example from:

```
3: x= 336.50 | y= -9.63 | z= 177.94

11: x= 0.06 | y= -0.13 | z= -0.13

10: x= -1000000.00 | y= -1000000.00 | z= -1000000.00
temperature: 28
```

to:
```
Orient: x= 335.69 |     y= -9.63 |      z= 177.87
Rot:    x= 0.13 |       y= -0.13 |      z= 0.00
Unk:    x= -1000000.00 |        y= -1000000.00 |        z= -1000000.00

temperature: 28
--
```