### PR TITLE
Adding calibration values for read_all_data.ino example

### DIFF
--- a/examples/read_all_data/read_all_data.ino
+++ b/examples/read_all_data/read_all_data.ino
@@ -67,6 +67,18 @@ void loop(void)
   Serial.print(F("temperature: "));
   Serial.println(boardTemp);
 
+  uint8_t system, gyro, accel, mag = 0;
+  bno.getCalibration(&system, &gyro, &accel, &mag);
+  Serial.println();
+  Serial.print("Calibration: Sys=");
+  Serial.print(system);
+  Serial.print(" Gyro=");
+  Serial.print(gyro);
+  Serial.print(" Accel=");
+  Serial.print(accel);
+  Serial.print(" Mag=");
+  Serial.println(mag);
+
   Serial.println("--");
   delay(BNO055_SAMPLERATE_DELAY_MS);
 }


### PR DESCRIPTION
Adding calibration values, with output:
```
Orient: x= 334.94 |     y= -9.38 |      z= 177.87
Rot:    x= 0.00 |       y= 0.06 |       z= 0.00
Unk:    x= -1000000.00 |        y= -1000000.00 |        z= -1000000.00

temperature: 29

Calibration: Sys=0 Gyro=3 Accel=1 Mag=0
--
```
