### PR TITLE
Fixing linear acceleration for read_all_data.ino

### DIFF
--- a/examples/read_all_data/read_all_data.ino
+++ b/examples/read_all_data/read_all_data.ino
@@ -105,9 +105,9 @@ void printEvent(sensors_event_t* event) {
   }
   else if (event->type == SENSOR_TYPE_LINEAR_ACCELERATION) {
     Serial.print("Linear:");
-    x = event->gyro.x;
-    y = event->gyro.y;
-    z = event->gyro.z;
+    x = event->acceleration.x;
+    y = event->acceleration.y;
+    z = event->acceleration.z;
   }
   else {
     Serial.print("Unk:");

--- a/examples/read_all_data/read_all_data.ino
+++ b/examples/read_all_data/read_all_data.ino
@@ -96,12 +96,20 @@ void printEvent(sensors_event_t* event) {
     x = event->gyro.x;
     y = event->gyro.y;
     z = event->gyro.z;
-  } else if (event->type == SENSOR_TYPE_ROTATION_VECTOR) {
+  }
+  else if (event->type == SENSOR_TYPE_ROTATION_VECTOR) {
     Serial.print("Rot:");
     x = event->gyro.x;
     y = event->gyro.y;
     z = event->gyro.z;
-  } else {
+  }
+  else if (event->type == SENSOR_TYPE_LINEAR_ACCELERATION) {
+    Serial.print("Linear:");
+    x = event->gyro.x;
+    y = event->gyro.y;
+    z = event->gyro.z;
+  }
+  else {
     Serial.print("Unk:");
   }
 


### PR DESCRIPTION
Updating read_all_data.ino to support linear acceleration. The output is updated from:
```
Orient: x= 333.94 |     y= -9.38 |      z= 177.75
Rot:    x= -0.06 |      y= 0.00 |       z= 0.13
Unk:    x= -1000000.00 |        y= -1000000.00 |        z= -1000000.00

temperature: 30
--
```

to:

```
Orient: x= 335.37 |     y= -9.38 |      z= 177.87
Rot:    x= 0.06 |       y= 0.00 |       z= 0.00
Linear: x= 0.00 |       y= 0.02 |       z= 0.01

temperature: 30
--
```
