### PR TITLE
Add function to enable 16G readings from accelerometer

### DIFF
--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -237,45 +237,30 @@ void Adafruit_BNO055::setExtCrystalUse(boolean usextal) {
 
 
 
-// This function will set the accelerometer configuration to 16G
+/*!
+ *  @brief  Set the Accelerometer to report up to 16G
+ */
 void Adafruit_BNO055::setAccelConfig16G()
 {
-    adafruit_bno055_opmode_t modeback = _mode;
+  adafruit_bno055_opmode_t modeback = _mode;
     
-    setMode(OPERATION_MODE_CONFIG);
-    delay(250);
+  setMode(OPERATION_MODE_CONFIG);
+  delay(250);
     
-    write8(BNO055_PAGE_ID_ADDR, 1);
-    delay(500);
+  write8(BNO055_PAGE_ID_ADDR, 1);
+  delay(500);
     
-    uint8_t acc_config_16G = (uint8_t)((BNO055_ACC_PWRMODE_NORMAL << 5)
-                                       | (BNO055_ACC_BW_125_HZ << 2)
-                                       | BNO055_ACC_CONFIG_16G);
-   /* Serial.print("AMG Config: ");
-    Serial.println(acc_config_16G);
-    Serial.print("Swtiching back to: ");
-    Serial.println(modeback);*/
+  uint8_t acc_config_16G = (uint8_t)((BNO055_ACC_PWRMODE_NORMAL << 5)
+                                   | (BNO055_ACC_BW_125_HZ      << 2)
+                                   |  BNO055_ACC_CONFIG_16G);
+  // Configure the accelerometer to report up to 16G of acceleration
+  write8(ACC_CONFIG, acc_config_16G);
+  delay(500);
+        
+  write8(BNO055_PAGE_ID_ADDR, 0);
     
-    // Configure the accelerometer to 16G
-    
-    write8(ACC_CONFIG, acc_config_16G);
-    delay(500);
-    
-    
-    /*Serial.print("We're on page: ");
-    Serial.println(read8(BNO055_PAGE_ID_ADDR));
-    byte regout;
-    regout = read8(ACC_CONFIG);
-    Serial.print("Reading config back: ");
-    Serial.println(regout);*/
-    
-    write8(BNO055_PAGE_ID_ADDR, 0);
-    
-    setMode(modeback);
-    delay(20);
-    
-    
-
+  setMode(modeback);
+  delay(20);
 }
 
 

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -235,6 +235,50 @@ void Adafruit_BNO055::setExtCrystalUse(boolean usextal) {
   delay(20);
 }
 
+
+
+// This function will set the accelerometer configuration to 16G
+void Adafruit_BNO055::setAccelConfig16G()
+{
+    adafruit_bno055_opmode_t modeback = _mode;
+    
+    setMode(OPERATION_MODE_CONFIG);
+    delay(250);
+    
+    write8(BNO055_PAGE_ID_ADDR, 1);
+    delay(500);
+    
+    uint8_t acc_config_16G = (uint8_t)((BNO055_ACC_PWRMODE_NORMAL << 5)
+                                       | (BNO055_ACC_BW_125_HZ << 2)
+                                       | BNO055_ACC_CONFIG_16G);
+   /* Serial.print("AMG Config: ");
+    Serial.println(acc_config_16G);
+    Serial.print("Swtiching back to: ");
+    Serial.println(modeback);*/
+    
+    // Configure the accelerometer to 16G
+    
+    write8(ACC_CONFIG, acc_config_16G);
+    delay(500);
+    
+    
+    /*Serial.print("We're on page: ");
+    Serial.println(read8(BNO055_PAGE_ID_ADDR));
+    byte regout;
+    regout = read8(ACC_CONFIG);
+    Serial.print("Reading config back: ");
+    Serial.println(regout);*/
+    
+    write8(BNO055_PAGE_ID_ADDR, 0);
+    
+    setMode(modeback);
+    delay(20);
+    
+    
+
+}
+
+
 /*!
  *   @brief  Gets the latest system status info
  *   @param  system_status

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -215,7 +215,7 @@ public:
     ACCEL_RADIUS_LSB_ADDR = 0X67,
     ACCEL_RADIUS_MSB_ADDR = 0X68,
     MAG_RADIUS_LSB_ADDR = 0X69,
-    MAG_RADIUS_MSB_ADDR = 0X6A
+    MAG_RADIUS_MSB_ADDR = 0X6A,
       
     /* Accelerometer Config Register */
     ACC_CONFIG = 0x08

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -38,6 +38,11 @@
 /** Offsets registers **/
 #define NUM_BNO055_OFFSET_REGISTERS (22)
 
+
+#define BNO055_ACC_PWRMODE_NORMAL (0)
+#define BNO055_ACC_BW_125_HZ (4)
+#define BNO055_ACC_CONFIG_16G (3)
+
 /** A structure to represent offsets **/
 typedef struct {
   int16_t accel_offset_x; /**< x acceleration offset */
@@ -211,6 +216,10 @@ public:
     ACCEL_RADIUS_MSB_ADDR = 0X68,
     MAG_RADIUS_LSB_ADDR = 0X69,
     MAG_RADIUS_MSB_ADDR = 0X6A
+      
+    /* Accelerometer Config Register */
+    ACC_CONFIG = 0x08
+      
   } adafruit_bno055_reg_t;
 
   /** BNO055 power settings */
@@ -313,6 +322,9 @@ public:
   /* Power managments functions */
   void enterSuspendMode();
   void enterNormalMode();
+  
+  /* Enabled 16G Mode */
+  void setAccelConfig16G();
 
 private:
   byte read8(adafruit_bno055_reg_t);

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -38,7 +38,7 @@
 /** Offsets registers **/
 #define NUM_BNO055_OFFSET_REGISTERS (22)
 
-
+/** Accelerometer config values **/
 #define BNO055_ACC_PWRMODE_NORMAL (0)
 #define BNO055_ACC_BW_125_HZ (4)
 #define BNO055_ACC_CONFIG_16G (3)
@@ -203,7 +203,7 @@ public:
     MAG_OFFSET_Z_LSB_ADDR = 0X5F,
     MAG_OFFSET_Z_MSB_ADDR = 0X60,
 
-    /* Gyroscope Offset register s*/
+    /* Gyroscope Offset registers */
     GYRO_OFFSET_X_LSB_ADDR = 0X61,
     GYRO_OFFSET_X_MSB_ADDR = 0X62,
     GYRO_OFFSET_Y_LSB_ADDR = 0X63,
@@ -217,7 +217,7 @@ public:
     MAG_RADIUS_LSB_ADDR = 0X69,
     MAG_RADIUS_MSB_ADDR = 0X6A,
       
-    /* Accelerometer Config Register */
+    /* Accelerometer config register */
     ACC_CONFIG = 0x08
       
   } adafruit_bno055_reg_t;
@@ -323,7 +323,7 @@ public:
   void enterSuspendMode();
   void enterNormalMode();
   
-  /* Enabled 16G Mode */
+  /* Accelerometer config functions */
   void setAccelConfig16G();
 
 private:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 ## Modified driver ##
 Added function to BNO object, simply call bno.setAccelConfig16G()
 Must ensure BNO is not in fusion mode, as that will limit output to 4G (~39), you probably want AMG (accelerometer, gyro, mag) mode 
-================
+
+
+---
+
+
+
+
+
+
+
+
 Adafruit Unified BNO055 Driver (AHRS/Orientation)  [![Build Status](https://travis-ci.com/DavidoRotho/Adafruit_BNO055.svg?branch=master)](https://travis-ci.com/DavidoRotho/Adafruit_BNO055)
 ================
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,7 @@
 ## Modified driver ##
 Added function to BNO object, simply call bno.setAccelConfig16G()
 Must ensure BNO is not in fusion mode, as that will limit output to 4G (~39), you probably want AMG (accelerometer, gyro, mag) mode 
-
 ================
-
-
-
-
-
 Adafruit Unified BNO055 Driver (AHRS/Orientation)  [![Build Status](https://travis-ci.com/DavidoRotho/Adafruit_BNO055.svg?branch=master)](https://travis-ci.com/DavidoRotho/Adafruit_BNO055)
 ================
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Added function to BNO object, simply call bno.setAccelConfig16G()
 Must ensure BNO is not in fusion mode, as that will limit output to 4G (~39), you probably want AMG (accelerometer, gyro, mag) mode 
 
 ================
-================
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
-# Modified driver
-## Added function to BNO object, simply call bno.setAccelConfig16G()
-## Must ensure BNO is not in fusion mode, as that will limit output to 4G (~39), you probably want AMG (accelerometer, gyro, mag) mode 
+## Modified driver ##
+Added function to BNO object, simply call bno.setAccelConfig16G()
+Must ensure BNO is not in fusion mode, as that will limit output to 4G (~39), you probably want AMG (accelerometer, gyro, mag) mode 
+
+================
+================
 
 
 
 
-Adafruit Unified BNO055 Driver (AHRS/Orientation)  [![Build Status](https://travis-ci.com/adafruit/Adafruit_BNO055.svg?branch=master)](https://travis-ci.com/adafruit/Adafruit_BNO055)
+Adafruit Unified BNO055 Driver (AHRS/Orientation)  [![Build Status](https://travis-ci.com/DavidoRotho/Adafruit_BNO055.svg?branch=master)](https://travis-ci.com/DavidoRotho/Adafruit_BNO055)
 ================
 
 <a href="https://www.adafruit.com/product/2472"><img src="assets/board.jpg?raw=true" width="500px"></a>

--- a/README.md
+++ b/README.md
@@ -1,17 +1,3 @@
-## Modified driver ##
-Added function to BNO object, simply call bno.setAccelConfig16G()
-Must ensure BNO is not in fusion mode, as that will limit output to 4G (~39), you probably want AMG (accelerometer, gyro, mag) mode 
-
-
----
-
-
-
-
-
-
-
-
 Adafruit Unified BNO055 Driver (AHRS/Orientation)  [![Build Status](https://travis-ci.com/DavidoRotho/Adafruit_BNO055.svg?branch=master)](https://travis-ci.com/DavidoRotho/Adafruit_BNO055)
 ================
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Adafruit Unified BNO055 Driver (AHRS/Orientation)  [![Build Status](https://travis-ci.com/DavidoRotho/Adafruit_BNO055.svg?branch=master)](https://travis-ci.com/DavidoRotho/Adafruit_BNO055)
+Adafruit Unified BNO055 Driver (AHRS/Orientation)  [![Build Status](https://travis-ci.com/adafruit/Adafruit_BNO055.svg?branch=master)](https://travis-ci.com/adafruit/Adafruit_BNO055)
 ================
 
 <a href="https://www.adafruit.com/product/2472"><img src="assets/board.jpg?raw=true" width="500px"></a>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Modified driver
+## Added function to BNO object, simply call bno.setAccelConfig16G()
+## Must ensure BNO is not in fusion mode, as that will limit output to 4G (~39), you probably want AMG (accelerometer, gyro, mag) mode 
+
+
+
+
 Adafruit Unified BNO055 Driver (AHRS/Orientation)  [![Build Status](https://travis-ci.com/adafruit/Adafruit_BNO055.svg?branch=master)](https://travis-ci.com/adafruit/Adafruit_BNO055)
 ================
 


### PR DESCRIPTION
### Describe the scope of your change--i.e. what the change does and what parts  of the code were modified.

This change adds a function that enables the accelerometer on the BNO to read up to 16G instead of the default 8G, which was needed by our team for measuring rocket acceleration as it was capping out on previous launches. I've done my best to try and bring the changes in line with the style that I've seen in this repo

### Describe any known limitations with your change.

This change only works with the BNO055 out of fusion mode, more a limitation of the device


### Please run any tests or examples that can exercise your modified code.

This modified driver was used in a rocket launch and successfully measured up to 16G.


If there's any further changes you'd like me to make or anything I can add to get this up to scratch to be merged, please let me know and I will action as soon as I can. Thanks :)