### PR TITLE
Change gyro units and fix gravity sensor type

### DIFF
--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -542,7 +542,7 @@ bool Adafruit_BNO055::getEvent(sensors_event_t *event,
     event->acceleration.y = vec.y();
     event->acceleration.z = vec.z();
   } else if (vec_type == Adafruit_BNO055::VECTOR_GRAVITY) {
-    event->type = SENSOR_TYPE_ACCELEROMETER;
+    event->type = SENSOR_TYPE_GRAVITY;
     vec = getVector(Adafruit_BNO055::VECTOR_GRAVITY);
 
     event->acceleration.x = vec.x();
@@ -556,12 +556,12 @@ bool Adafruit_BNO055::getEvent(sensors_event_t *event,
     event->orientation.y = vec.y();
     event->orientation.z = vec.z();
   } else if (vec_type == Adafruit_BNO055::VECTOR_GYROSCOPE) {
-    event->type = SENSOR_TYPE_ROTATION_VECTOR;
+    event->type = SENSOR_TYPE_GYROSCOPE;
     vec = getVector(Adafruit_BNO055::VECTOR_GYROSCOPE);
 
-    event->gyro.x = vec.x();
-    event->gyro.y = vec.y();
-    event->gyro.z = vec.z();
+    event->gyro.x = vec.x() * SENSORS_DPS_TO_RADS;
+    event->gyro.y = vec.y() * SENSORS_DPS_TO_RADS;
+    event->gyro.z = vec.z() * SENSORS_DPS_TO_RADS;
   } else if (vec_type == Adafruit_BNO055::VECTOR_MAGNETOMETER) {
     event->type = SENSOR_TYPE_MAGNETIC_FIELD;
     vec = getVector(Adafruit_BNO055::VECTOR_MAGNETOMETER);

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -149,7 +149,6 @@ public:
 
     /* Unit selection register */
     BNO055_UNIT_SEL_ADDR = 0X3B,
-    BNO055_DATA_SELECT_ADDR = 0X3C,
 
     /* Mode registers */
     BNO055_OPR_MODE_ADDR = 0X3D,

--- a/examples/read_all_data/read_all_data.ino
+++ b/examples/read_all_data/read_all_data.ino
@@ -127,6 +127,12 @@ void printEvent(sensors_event_t* event) {
     y = event->acceleration.y;
     z = event->acceleration.z;
   }
+  else if (event->type == SENSOR_TYPE_GRAVITY) {
+    Serial.print("Gravity:");
+    x = event->acceleration.x;
+    y = event->acceleration.y;
+    z = event->acceleration.z;
+  }
   else {
     Serial.print("Unk:");
   }


### PR DESCRIPTION
Possible fixes for #76 and #50.

The BNO055 has the ability to set to different engineering units. There is some commented out code that sets the gyro to the non-default rad/s option:
https://github.com/adafruit/Adafruit_BNO055/blob/c70a80e3ce57294cb89990b150982a4d60929159/Adafruit_BNO055.cpp#L110-L118
with the default being deg/s. This PR leaves that as is and then adjust later when filling out the `sensor_event_t` for the gyro case. Sensor type for gravity also changed and example updated:

![Screenshot from 2021-08-12 15-32-17](https://user-images.githubusercontent.com/8755041/129278701-d2ff58dc-be11-443c-bc8b-66e872675b04.png)

