### PR TITLE
Added a public method to get the current operating mode

### DIFF
--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -159,26 +159,12 @@ void Adafruit_BNO055::setMode(adafruit_bno055_opmode_t mode) {
 }
 
 /*!
- *  @brief  Gets the current  operating mode of the chip
- *  @param  mode
- *          mode values
- *           [OPERATION_MODE_CONFIG,
- *            OPERATION_MODE_ACCONLY,
- *            OPERATION_MODE_MAGONLY,
- *            OPERATION_MODE_GYRONLY,
- *            OPERATION_MODE_ACCMAG,
- *            OPERATION_MODE_ACCGYRO,
- *            OPERATION_MODE_MAGGYRO,
- *            OPERATION_MODE_AMG,
- *            OPERATION_MODE_IMUPLUS,
- *            OPERATION_MODE_COMPASS,
- *            OPERATION_MODE_M4G,
- *            OPERATION_MODE_NDOF_FMC_OFF,
- *            OPERATION_MODE_NDOF]
+ *  @brief  Gets the current operating mode of the chip
+ *  @return  operating_mode
  */
 uint8_t Adafruit_BNO055::getMode() {
-   uint8_t _my_mode_return = (uint8_t)read8(BNO055_OPR_MODE_ADDR);
-   return _my_mode_return;
+   uint8_t operating_mode = read8(BNO055_OPR_MODE_ADDR);
+   return operating_mode;
 }
 
 /*!

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -163,8 +163,8 @@ void Adafruit_BNO055::setMode(adafruit_bno055_opmode_t mode) {
  *  @return  operating_mode in integer which can be mapped in Section 3.3
  *           for example: a return of 12 (0X0C) => NDOF
  */
-uint8_t Adafruit_BNO055::getMode() {
-  uint8_t operating_mode = read8(BNO055_OPR_MODE_ADDR);
+adafruit_bno055_opmode_t Adafruit_BNO055::getMode() {
+  adafruit_bno055_opmode_t operating_mode = read8(BNO055_OPR_MODE_ADDR);
   return operating_mode;
 }
 

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -160,7 +160,8 @@ void Adafruit_BNO055::setMode(adafruit_bno055_opmode_t mode) {
 
 /*!
  *  @brief  Gets the current operating mode of the chip
- *  @return  operating_mode in integer which can be mapped in Section 3.3 e.g.Return 12 (0X0C) => NDOF
+ *  @return  operating_mode in integer which can be mapped in Section 3.3
+ *           for example: a return of 12 (0X0C) => NDOF
  */
 uint8_t Adafruit_BNO055::getMode() {
    uint8_t operating_mode = read8(BNO055_OPR_MODE_ADDR);

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -159,6 +159,29 @@ void Adafruit_BNO055::setMode(adafruit_bno055_opmode_t mode) {
 }
 
 /*!
+ *  @brief  Gets the current  operating mode of the chip
+ *  @param  mode
+ *          mode values
+ *           [OPERATION_MODE_CONFIG,
+ *            OPERATION_MODE_ACCONLY,
+ *            OPERATION_MODE_MAGONLY,
+ *            OPERATION_MODE_GYRONLY,
+ *            OPERATION_MODE_ACCMAG,
+ *            OPERATION_MODE_ACCGYRO,
+ *            OPERATION_MODE_MAGGYRO,
+ *            OPERATION_MODE_AMG,
+ *            OPERATION_MODE_IMUPLUS,
+ *            OPERATION_MODE_COMPASS,
+ *            OPERATION_MODE_M4G,
+ *            OPERATION_MODE_NDOF_FMC_OFF,
+ *            OPERATION_MODE_NDOF]
+ */
+uint8_t Adafruit_BNO055::getMode() {
+   uint8_t _my_mode_return = (uint8_t)read8(BNO055_OPR_MODE_ADDR);
+   return _my_mode_return;
+}
+
+/*!
  *  @brief  Changes the chip's axis remap
  *  @param  remapcode
  *          remap code possible values

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -164,8 +164,8 @@ void Adafruit_BNO055::setMode(adafruit_bno055_opmode_t mode) {
  *           for example: a return of 12 (0X0C) => NDOF
  */
 uint8_t Adafruit_BNO055::getMode() {
-   uint8_t operating_mode = read8(BNO055_OPR_MODE_ADDR);
-   return operating_mode;
+  uint8_t operating_mode = read8(BNO055_OPR_MODE_ADDR);
+  return operating_mode;
 }
 
 /*!

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -160,7 +160,7 @@ void Adafruit_BNO055::setMode(adafruit_bno055_opmode_t mode) {
 
 /*!
  *  @brief  Gets the current operating mode of the chip
- *  @return  operating_mode
+ *  @return  operating_mode in integer which can be mapped in Section 3.3 e.g.Return 12 (0X0C) => NDOF
  */
 uint8_t Adafruit_BNO055::getMode() {
    uint8_t operating_mode = read8(BNO055_OPR_MODE_ADDR);

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -284,6 +284,7 @@ public:
 
   bool begin(adafruit_bno055_opmode_t mode = OPERATION_MODE_NDOF);
   void setMode(adafruit_bno055_opmode_t mode);
+  uint8_t getMode();
   void setAxisRemap(adafruit_bno055_axis_remap_config_t remapcode);
   void setAxisSign(adafruit_bno055_axis_remap_sign_t remapsign);
   void getRevInfo(adafruit_bno055_rev_info_t *);

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -284,7 +284,7 @@ public:
 
   bool begin(adafruit_bno055_opmode_t mode = OPERATION_MODE_NDOF);
   void setMode(adafruit_bno055_opmode_t mode);
-  uint8_t getMode();
+  adafruit_bno055_opmode_t getMode();
   void setAxisRemap(adafruit_bno055_axis_remap_config_t remapcode);
   void setAxisSign(adafruit_bno055_axis_remap_sign_t remapsign);
   void getRevInfo(adafruit_bno055_rev_info_t *);


### PR DESCRIPTION
Hello Adafruit, thanks for this library.

The change that I added was to add a public method to make the current "operating mode" of the chip available. The reason for the change was that when I was learning about the BNO055 I found it hard to find what operating mode I was using. The NDOF mode is set as default as part of the `begin()` method in this library. But in the BNO055 datasheet it says "The default operation mode after power-on is CONFIGMODE." so I was unsure as to the operation. This method will hopefully make it clearer as to which operating mode is used, and easier to access for library users.