### PR TITLE
Add functions for greater control over axis remap

### DIFF
--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -235,6 +235,73 @@ void Adafruit_BNO055::setAxisSign(adafruit_bno055_axis_remap_sign_t remapsign) {
 }
 
 /*!
+ * @brief Configure the axis of the device to a new reference axis
+ * 
+ * @param x_axis 
+ *        axis to remap x_axis to
+ * @param y_axis 
+ *        axis to remap y_axis to
+ * @param z_axis 
+ *        axis to remap z_axis to
+ * @return true if new axis configuration valid
+ */
+bool Adafruit_BNO055::configureAxisRemap(adafruit_bno055_remap_axis_t x_axis,
+                                         adafruit_bno055_remap_axis_t y_axis,
+                                         adafruit_bno055_remap_axis_t z_axis){
+  adafruit_bno055_opmode_t modeback = _mode;
+
+  byte write_val = 0;
+  write_val = write_val | x_axis;
+  write_val = write_val | (y_axis << 2);
+  write_val = write_val | (z_axis << 4);
+
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
+  write8(BNO055_AXIS_MAP_CONFIG_ADDR, write_val);
+  delay(10);
+
+  /* Set the requested operating mode (see section 3.3) */
+  setMode(modeback);
+  delay(20);
+
+  return (read8(BNO055_AXIS_MAP_CONFIG_ADDR) == write_val);
+}
+
+/*!
+ * @brief Configure the signs of the device's reference axis
+ * 
+ * @param x_sign 
+ *        sign to set the x_axis to
+ * @param y_sign 
+ *        sign to set the y_axis to
+ * @param z_sign 
+ *        sign to set the z_axis to
+ * @return true if sign configuration is valid
+ */
+bool Adafruit_BNO055::configureAxisSign(adafruit_bno055_remap_sign_t x_sign,
+                                        adafruit_bno055_remap_sign_t y_sign,
+                                        adafruit_bno055_remap_sign_t z_sign){
+  adafruit_bno055_opmode_t modeback = _mode;
+
+  byte write_val = 0;
+  write_val = write_val | z_sign;
+  write_val = write_val | (y_sign << 1);
+  write_val = write_val | (x_sign << 2);
+
+  setMode(OPERATION_MODE_CONFIG);
+  delay(25);
+  write8(BNO055_AXIS_MAP_SIGN_ADDR, write_val);
+  delay(10);
+
+  /* Set the requested operating mode (see section 3.3) */
+  setMode(modeback);
+  delay(20);
+
+  return (read8(BNO055_AXIS_MAP_SIGN_ADDR) == write_val);
+}
+
+
+/*!
  *  @brief  Use the external 32.768KHz crystal
  *  @param  usextal
  *          use external crystal boolean

--- a/Adafruit_BNO055.cpp
+++ b/Adafruit_BNO055.cpp
@@ -236,18 +236,17 @@ void Adafruit_BNO055::setAxisSign(adafruit_bno055_axis_remap_sign_t remapsign) {
 
 /*!
  * @brief Configure the axis of the device to a new reference axis
- * 
- * @param x_axis 
+ * @param x_axis
  *        axis to remap x_axis to
- * @param y_axis 
+ * @param y_axis
  *        axis to remap y_axis to
- * @param z_axis 
+ * @param z_axis
  *        axis to remap z_axis to
  * @return true if new axis configuration valid
  */
 bool Adafruit_BNO055::configureAxisRemap(adafruit_bno055_remap_axis_t x_axis,
                                          adafruit_bno055_remap_axis_t y_axis,
-                                         adafruit_bno055_remap_axis_t z_axis){
+                                         adafruit_bno055_remap_axis_t z_axis) {
   adafruit_bno055_opmode_t modeback = _mode;
 
   byte write_val = 0;
@@ -269,18 +268,17 @@ bool Adafruit_BNO055::configureAxisRemap(adafruit_bno055_remap_axis_t x_axis,
 
 /*!
  * @brief Configure the signs of the device's reference axis
- * 
- * @param x_sign 
+ * @param x_sign
  *        sign to set the x_axis to
- * @param y_sign 
+ * @param y_sign
  *        sign to set the y_axis to
- * @param z_sign 
+ * @param z_sign
  *        sign to set the z_axis to
  * @return true if sign configuration is valid
  */
 bool Adafruit_BNO055::configureAxisSign(adafruit_bno055_remap_sign_t x_sign,
                                         adafruit_bno055_remap_sign_t y_sign,
-                                        adafruit_bno055_remap_sign_t z_sign){
+                                        adafruit_bno055_remap_sign_t z_sign) {
   adafruit_bno055_opmode_t modeback = _mode;
 
   byte write_val = 0;
@@ -299,7 +297,6 @@ bool Adafruit_BNO055::configureAxisSign(adafruit_bno055_remap_sign_t x_sign,
 
   return (read8(BNO055_AXIS_MAP_SIGN_ADDR) == write_val);
 }
-
 
 /*!
  *  @brief  Use the external 32.768KHz crystal

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -260,12 +260,14 @@ public:
     REMAP_SIGN_P7 = 0x05
   } adafruit_bno055_axis_remap_sign_t;
 
+  /** Axis Remap Enums **/
   typedef enum {
     REMAP_X_AXIS = 0b00,
     REMAP_Y_AXIS = 0b01,
     REMAP_Z_AXIS = 0b10,
   } adafruit_bno055_remap_axis_t;
 
+  /** Axis Sign Enums**/
   typedef enum {
     REMAP_SIGN_POS = 0,
     REMAP_SIGN_NEG = 1,
@@ -327,7 +329,7 @@ public:
   void setSensorOffsets(const adafruit_bno055_offsets_t &offsets_type);
   bool isFullyCalibrated();
 
-  /* Power managments functions */
+  /* Power management functions */
   void enterSuspendMode();
   void enterNormalMode();
 

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -260,6 +260,17 @@ public:
     REMAP_SIGN_P7 = 0x05
   } adafruit_bno055_axis_remap_sign_t;
 
+  typedef enum {
+    REMAP_X_AXIS = 0b00,
+    REMAP_Y_AXIS = 0b01,
+    REMAP_Z_AXIS = 0b10,
+  } adafruit_bno055_remap_axis_t;
+
+  typedef enum {
+    REMAP_SIGN_POS = 0,
+    REMAP_SIGN_NEG = 1,
+  }adafruit_bno055_remap_sign_t;
+
   /** A structure to represent revisions **/
   typedef struct {
     uint8_t accel_rev; /**< acceleration rev */
@@ -287,6 +298,12 @@ public:
   adafruit_bno055_opmode_t getMode();
   void setAxisRemap(adafruit_bno055_axis_remap_config_t remapcode);
   void setAxisSign(adafruit_bno055_axis_remap_sign_t remapsign);
+  bool configureAxisRemap(adafruit_bno055_remap_axis_t x_axis,
+                          adafruit_bno055_remap_axis_t y_axis,
+                          adafruit_bno055_remap_axis_t z_axis);
+  bool configureAxisSign(adafruit_bno055_remap_sign_t x_sign,
+                         adafruit_bno055_remap_sign_t y_sign,
+                         adafruit_bno055_remap_sign_t z_sign);
   void getRevInfo(adafruit_bno055_rev_info_t *);
   void setExtCrystalUse(boolean usextal);
   void getSystemStatus(uint8_t *system_status, uint8_t *self_test_result,

--- a/Adafruit_BNO055.h
+++ b/Adafruit_BNO055.h
@@ -269,7 +269,7 @@ public:
   typedef enum {
     REMAP_SIGN_POS = 0,
     REMAP_SIGN_NEG = 1,
-  }adafruit_bno055_remap_sign_t;
+  } adafruit_bno055_remap_sign_t;
 
   /** A structure to represent revisions **/
   typedef struct {


### PR DESCRIPTION
Based on Section 3.4 Axis Remap of the BNO055 Datasheet, 2 functions providing greater control of Axis remapping are provided.
- `configureAxisRemap` allows the user to remap the X, Y and Z axis to another axis
- `configureAxisSign` allows the user to remap the signs of the X, Y and Z axis.

Although the original library provides the functions `setAxisRemap` and `setAxisSign`, these functions are restrictive as they only allow the user to reconfigure the axis based on the example placements provided which would does not suit every use case. 

The 2 functions above return bool values that indicate if the configuration was successful. This is done by reading the configuration registers and checking if the value read from the registers match the new values initially rewritten. 

Also based on testing and this [forum post](https://forums.adafruit.com/viewtopic.php?t=180919), I realized that `setExtCrystalUse` can only be called after axis remapping. I feel this should be documented somewhere, as calling `setExtCrystalUse` before axis remapping would lead to axis remapping not working, with the default axis configurations applied instead of the new configuration.